### PR TITLE
Raise TypeError on f.trace[None]

### DIFF
--- a/python/segyio/depth.py
+++ b/python/segyio/depth.py
@@ -59,6 +59,10 @@ class Depth(Sequence):
         inline sorted file with 10 inlines and 5 crosslines has the shape
         (10,5). If the file is unsorted, the array shape == tracecount.
 
+        Be aware that this interface uses zero-based indices (like traces) and
+        *not keys* (like ilines), so you can *not* use the values file.samples
+        as indices.
+
         Parameters
         ----------
         i : int or slice
@@ -112,11 +116,17 @@ class Depth(Sequence):
             return self.filehandle.getdepth(i, buf.size, self.offsets, buf)
 
         except TypeError:
+            try:
+                indices = i.indices(len(self))
+            except AttributeError:
+                msg = 'depth indices must be integers or slices, not {}'
+                raise TypeError(msg.format(type(i).__name__))
+
             def gen():
                 x = np.empty(self.shape, dtype=self.dtype)
                 y = np.copy(x)
 
-                for j in range(*i.indices(len(self))):
+                for j in range(*indices):
                     self.filehandle.getdepth(j, x.size, self.offsets, x)
                     x, y = y, x
                     yield y

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -837,6 +837,35 @@ def test_fopen_error():
         segyio.open("test-data/small.sgy", "r+b+toolong")
 
 
+def test_getitem_None():
+    with pytest.raises(TypeError):
+        with segyio.open('test-data/small.sgy') as f:
+            _ = f.trace[None]
+
+    with pytest.raises(TypeError):
+        with segyio.open('test-data/small.sgy') as f:
+            _ = f.trace.raw[None]
+
+    with pytest.raises(TypeError):
+        with segyio.open('test-data/small.sgy') as f:
+            _ = f.header[None]
+
+    with pytest.raises(KeyError):
+        with segyio.open('test-data/small.sgy') as f:
+            _ = f.iline[None]
+
+    with pytest.raises(KeyError):
+        with segyio.open('test-data/small.sgy') as f:
+            _ = f.xline[None]
+
+    with pytest.raises(TypeError):
+        with segyio.open('test-data/small.sgy') as f:
+            _ = f.depth_slice[None]
+
+    with pytest.raises(TypeError):
+        with segyio.open('test-data/small.sgy') as f:
+            _ = f.gather[None]
+
 def test_wrong_lineno():
     with pytest.raises(KeyError):
         with segyio.open("test-data/small.sgy") as f:


### PR DESCRIPTION
Do the unpacking slice.indices when it is suspected the argument is a
range outside of the generator definition, and redirect the
AttributeError to a TypeError (which it really is). Otherwise the error
would first show up when the generator is accessed, instead of at the
actual site of error.