### PR TITLE
bswap16 short header words in field_forall

### DIFF
--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -1643,6 +1643,17 @@ def test_readtrace_int16():
         assert list(tr[40:19:-5]) == [-888, -2213, 5198, -1170, 0]
         assert list(tr[53:50:-1]) == [-2609, -2625, 681]
 
+def test_attributes_shortword_little_endian():
+    f3msb = 'test-data/f3.sgy'
+    f3lsb = 'test-data/f3-lsb.sgy'
+    word = segyio.su.dt
+    # this test (in particular) is a pretty good candidate for fuzzing
+    with segyio.open(f3msb) as msb:
+        with segyio.open(f3lsb, endian = 'little') as lsb:
+            msba = msb.attributes(word)
+            lsba = lsb.attributes(word)
+            npt.assert_array_equal(msba[:], lsba[:])
+
 
 @tmpfiles('test-data/f3.sgy')
 def test_writetrace_int16(tmpdir):


### PR DESCRIPTION
bswap32 cannot be indiscriminatly applied to the int32 temporary, as it
essentially is a byte-reorder and left-shift when applies to an int16.

The symptom is that certain header fields extracted this way show up in
the absurd range (some 65 million), when normal values are in the few
thousands, such as dt/sample-interval.

Addresses #368

https://github.com/equinor/segyio/issues/368