### PR TITLE
Modify docstring for open.py to clarify copy operation

### DIFF
--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -131,7 +131,7 @@ def open(filename, mode="r", iline = 189,
 
     Open two files at once:
 
-    >>> with segyio.open(path) as src, segyio.open(path, "r+") as dst:
+    >>> with segyio.open(src_path) as src, segyio.open(dst_path, "r+") as dst:
     ...     dst.trace = src.trace # copy all traces from src to dst
 
     Open a file little-endian file:


### PR DESCRIPTION
The docstring for open.py includes an example of copying
a file from a source to a destination.

In the previous version, this example uses the same filename
for the 'from' as for the 'to' open statements.

This could be confusing to users because, in practice,
a non-trivial use of this would need different filenames for the
'from' and 'to' open statements.

This commit gives two different filenames for 'from' and 'to'.