### PR TITLE
Fix grammar inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ are available:
 * `header`
 
     With addressing behaviour similar to `trace`, accessing items yield header
-    objects instead of numpy `ndarray`s. Headers are dict like objects, where
+    objects instead of numpy `ndarray`s. Headers are dict-like objects, where
     keys are integers, seismic unix-style keys (in segyio.su module) and segyio
     enums (segyio.TraceField).
 


### PR DESCRIPTION
Added hyphen to README.md:
'dict like' --> 'dict-like'

dict-like is used elsewhere in the readme,
and is the preferred way of writing this phrase.
This update adds a hyphen to one instance where
it had been left out.