### PR TITLE
Check volume consistency when loading as volume

### DIFF
--- a/lib/experimental/segyio/segyio.hpp
+++ b/lib/experimental/segyio/segyio.hpp
@@ -1590,6 +1590,11 @@ void volume_meta_fromfile< Derived >::operator()( segy_file* fp,
             throw unknown_error( err );
     }
 
+    if( (ils * xls) != self->tracecount() )
+        throw std::invalid_argument( "Inconsistent volume properties: "
+                                     "Inlinecount * crosslinecount "
+                                     "!= tracecount" );
+
     this->sort   = srt;
     this->ilines = ils;
     this->xlines = xls;


### PR DESCRIPTION
Check that (inlinecount * crosslinecount) == tracecount when
interpreting a file as volume.