### PR TITLE
Fix header assignment in pre-stack files

### DIFF
--- a/lib/experimental/segyio/segyio.hpp
+++ b/lib/experimental/segyio/segyio.hpp
@@ -423,6 +423,7 @@ public:
      * The optimiser should go ham on this and simply elide everything, while
      * still providing the correct static guarantees.
      */
+    explicit
     basic_file( const segyio::path& path,
                 const segyio::config& cfg = config() ) noexcept(false)
     : Traits< basic_file >( {} ) ... {

--- a/python/segyio/line.py
+++ b/python/segyio/line.py
@@ -487,19 +487,15 @@ class HeaderLine(Line):
 
         try: start = self.heads[index] + self.offsets[offset]
         except TypeError: pass
-
         else:
-            try:
-                if hasattr(val, 'keys'):
-                    val = itertools.repeat(val)
-            except TypeError:
-                # already an iterable
-                pass
-
             step = self.stride * len(self.offsets)
             stop  = start + step * self.length
             self.header[start:stop:step] = val
             return
+
+        # if this is a dict-like, just repeat it
+        if hasattr(val, 'keys'):
+            val = itertools.repeat(val)
 
         irange, orange = self.ranges(index, offset)
         val = iter(val)

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -381,6 +381,26 @@ def test_headers_line_offset(smallps):
         assert f.header[1][xl] == 13
         assert f.header[2][xl] == 2
 
+def test_write_headers_line_slice_offset_int(smallps):
+    il, xl = TraceField.INLINE_3D, TraceField.CROSSLINE_3D
+    with segyio.open(smallps, "r+") as f:
+        f.header.iline[1:3, 2] = {xl: 13}
+
+    with segyio.open(smallps, strict=False) as f:
+        assert f.header[0][xl] == 1
+        assert f.header[1][xl] == 13
+        assert f.header[2][xl] == 2
+        assert f.header[3][xl] == 13
+
+def test_write_headers_line_int_offset_slice(smallps):
+    il, xl = TraceField.INLINE_3D, TraceField.CROSSLINE_3D
+    with segyio.open(smallps, "r+") as f:
+        f.header.iline[1, :] = {xl: 13}
+
+    with segyio.open(smallps, strict=False) as f:
+        assert f.header[0][xl] == 13
+        assert f.header[1][xl] == 13
+        assert f.header[2][xl] == 13
 
 @pytest.mark.parametrize(('openfn', 'kwargs'), smallfiles)
 def test_attributes(openfn, kwargs):


### PR DESCRIPTION
Assigning to headers for slices of lines or offsets were broken,
courtesy of the iterability check being inside the wrong block.

Move the block to the right scope, and add tests for the syntax.