### PR TITLE
Import abstract base classes from collections.abc

### DIFF
--- a/python/segyio/depth.py
+++ b/python/segyio/depth.py
@@ -1,3 +1,8 @@
+try:
+    from collections.abc import Sequence # noqa
+except ImportError:
+    from collections import Sequence # noqa
+
 import numpy as np
 try: from future_builtins import zip
 except ImportError: pass
@@ -21,7 +26,7 @@ class Depth(Sequence):
     .. versionadded:: 1.1
 
     .. versionchanged:: 1.6
-        common list operations (collections.Sequence)
+        common list operations (Sequence)
 
     .. versionchanged:: 1.7.1
        enabled for unstructured files

--- a/python/segyio/field.py
+++ b/python/segyio/field.py
@@ -1,10 +1,15 @@
-import collections
+try:
+    from collections.abc import Mapping # noqa
+    from collections.abc import MutableMapping # noqa
+except ImportError:
+    from collections import Mapping # noqa
+    from collections import MutableMapping # noqa
 
 import segyio
 from .binfield import BinField
 from .tracefield import TraceField
 
-class Field(collections.MutableMapping):
+class Field(MutableMapping):
     """
     The Field implements the dict interface, with a fixed set of keys. It's
     used for both binary- and trace headers. Any modifications to this
@@ -22,7 +27,7 @@ class Field(collections.MutableMapping):
         common dict operations (update, keys, values)
 
     .. versionchanged:: 1.6
-        more common dict operations (collections.MutableMapping)
+        more common dict operations (MutableMapping)
     """
     _bin_keys = [x for x in BinField.enums()
                  if  x != BinField.Unassigned1
@@ -438,7 +443,7 @@ class Field(collections.MutableMapping):
     def __eq__(self, other):
         """x.__eq__(y) <==> x == y"""
 
-        if not isinstance(other, collections.Mapping):
+        if not isinstance(other, Mapping):
             return NotImplemented
 
         if len(self) != len(other):
@@ -492,13 +497,13 @@ class Field(collections.MutableMapping):
 
         buf = bytearray(self.buf)
 
-        # Implementation largely borrowed from collections.mapping
+        # Implementation largely borrowed from Mapping
         # If E present and has a .keys() method: for k in E: D[k] = E[k]
         # If E present and lacks .keys() method: for (k, v) in E: D[k] = v
         # In either case, this is followed by: for k, v in F.items(): D[k] = v
         if len(args) == 1:
             other = args[0]
-            if isinstance(other, collections.Mapping):
+            if isinstance(other, Mapping):
                 for key in other:
                     self.putfield(buf, int(key), other[key])
             elif hasattr(other, "keys"):

--- a/python/segyio/line.py
+++ b/python/segyio/line.py
@@ -1,4 +1,8 @@
-import collections
+try:
+    from collections.abc import Mapping # noqa
+except ImportError:
+    from collections import Mapping # noqa
+
 import itertools
 try: from future_builtins import zip
 except ImportError: pass
@@ -25,7 +29,7 @@ def sanitize_slice(s, source):
 
     return slice(start, stop, step)
 
-class Line(collections.Mapping):
+class Line(Mapping):
     """
     The Line implements the dict interface, with a fixed set of int_like keys,
     the line numbers/labels. Data is read lazily from disk, so iteration does
@@ -54,7 +58,7 @@ class Line(collections.Mapping):
     .. versionadded:: 1.1
 
     .. versionchanged:: 1.6
-        common dict operations (collections.Mapping)
+        common dict operations (Mapping)
     """
 
     def __init__(self, filehandle, labels, length, stride, offsets, name):
@@ -311,7 +315,7 @@ class Line(collections.Mapping):
                                            )
                 except StopIteration: return
 
-    # can't rely on most collections.Mapping default implementations of
+    # can't rely on most Mapping default implementations of
     # dict-like, because iter() does not yield keys for this class, it gives
     # the lines themselves. that violates some assumptions (but segyio's always
     # worked that way), and it's the more natural behaviour for segyio, so it's
@@ -352,7 +356,7 @@ class HeaderLine(Line):
     .. versionadded:: 1.1
 
     .. versionchanged:: 1.6
-        common dict operations (collections.Mapping)
+        common dict operations (Mapping)
     """
     # a lot of implementation details are shared between reading data traces
     # line-by-line and trace headers line-by-line, so (ab)use inheritance for

--- a/python/segyio/trace.py
+++ b/python/segyio/trace.py
@@ -1,4 +1,8 @@
-import collections
+try:
+    from collections.abc import Sequence # noqa
+except ImportError:
+    from collections import Sequence # noqa
+
 import contextlib
 import itertools
 import warnings
@@ -12,7 +16,7 @@ from .line import HeaderLine
 from .field import Field
 from .utils import castarray
 
-class Sequence(collections.Sequence):
+class Sequence(Sequence):
 
     # unify the common optimisations and boilerplate of Trace, RawTrace, and
     # Header, which all obey the same index-oriented interface, and all share
@@ -30,8 +34,8 @@ class Sequence(collections.Sequence):
 
     def __iter__(self):
         """x.__iter__() <==> iter(x)"""
-        # __iter__ has a reasonable default implementation from
-        # collections.Sequence. It's essentially this loop:
+        # __iter__ has a reasonable default implementation from Sequence. It's
+        # essentially this loop:
         # for i in range(len(self)): yield self[i]
         # However, in segyio that means the double-buffering, buffer reuse does
         # not happen, which is *much* slower (the allocation of otherwised
@@ -69,7 +73,7 @@ class Trace(Sequence):
     .. versionadded:: 1.1
 
     .. versionchanged:: 1.6
-        common list operations (collections.Sequence)
+        common list operations (Sequence)
 
     Examples
     --------
@@ -580,7 +584,7 @@ class Header(Sequence):
     .. versionadded:: 1.1
 
     .. versionchanged:: 1.6
-        common list operations (collections.Sequence)
+        common list operations (Sequence)
 
     """
     def __init__(self, segy):
@@ -852,7 +856,7 @@ class Text(Sequence):
     Notes
     -----
     .. versionchanged:: 1.7
-        common list operations (collections.Sequence)
+        common list operations (Sequence)
 
     """
 


### PR DESCRIPTION
In python 3.8 [1], importing the abstract base classes from collections
will break. Simply changing the import is both backwards and forward
compatible.

[1] DeprecationWarning: Using or importing the ABCs from 'collections'
    instead of from 'collections.abc' is deprecated, and in 3.8 it will
    stop working

Closes #403 