### PR TITLE
Remove conversion warning

### DIFF
--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -1426,7 +1426,7 @@ def test_create_from_naught_unstructured(endian, tmpdir):
         assert 1 == f.header[1][TraceField.offset]
 
 def test_create_non_4byte_file(tmpdir):
-    ref_trace = [2, 1, 4]
+    ref_trace = np.array([2, 1, 4], np.int8)
 
     spec = segyio.spec()
     spec.format = 8


### PR DESCRIPTION
A list being converted to a numpy array was causing a performance
warning to be emitted.