### PR TITLE
Point out sparse file writes in common issues

### DIFF
--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -146,6 +146,8 @@ def create(filename, spec):
     ...     with segyio.create(dstpath, spec) as dst:
     ...         dst.text[0] = src.text[0]
     ...         dst.bin = src.bin
+    ...         # this is writing a sparse file, which might be slow on some
+    ...         # systems
     ...         dst.header = src.header
     ...         dst.trace = src.trace
 


### PR DESCRIPTION
The issue of slow header writes pop up quite often, and it's likely that
the culprit is actually a slow file system for sparse writes. It is
certainly useful to point this out in the common issues section in the
readme, as well as briefly mention sparse writes in the docs for create.