### PR TITLE
Wrap catr t/r arg parsing in compound statement

### DIFF
--- a/applications/segyio-catr.c
+++ b/applications/segyio-catr.c
@@ -517,7 +517,7 @@ static struct options parse_options( int argc, char** argv ){
                      break;
 
            case 'r': // intentional fallthrough
-           case 't':
+           case 't': {
                 if( opts.rsize == rallocsize ) {
                     rallocsize *= 2;
                     range* re = realloc( opts.r, rallocsize*sizeof( range ) );
@@ -583,6 +583,7 @@ static struct options parse_options( int argc, char** argv ){
                 }
 
                 done: ++opts.rsize; break;
+            }
 
            default: opts.help = 1; opts.errmsg = ""; return opts;
        }


### PR DESCRIPTION
The control flow for the t/r-case is pretty heavy, and uses a goto for
early exit. This label was made a case label in the switch by accident,
which was happily jumped to, but is wrong and awkward.

Wrapping the whole case in a compound statement provides some micro
isolation, but more importantly makes the done label a proper goto
label, not a switch case.

Closes #436 