### PR TITLE
Decode text in tools.wrap

### DIFF
--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -100,26 +100,32 @@ def create_text_header(lines):
 def wrap(s, width=80):
     """
     Formats the text input with newlines given the user specified width for
-    each line.
+    each line. `wrap` will attempt to decode the input as ascii, ignoring any
+    errors, which occurs with many headers in ebcdic. To consider encoding
+    errors, decode the textual header before passing it to wrap.
 
     Parameters
     ----------
-
-    s : str
+    s : text or bytearray or str
     width : int
 
     Returns
     -------
-
     text : str
 
     Notes
     -----
-
     .. versionadded:: 1.1
 
     """
-    return '\n'.join(textwrap.wrap(str(s), width=width))
+    try:
+        s = s.decode(errors = 'ignore')
+    except AttributeError:
+        # Already str-like enough, e.g. wrap(f.text[0].decode()), so just try
+        # to wrap-join
+        pass
+
+    return '\n'.join(textwrap.wrap(s, width=width))
 
 
 def native(data,

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -67,6 +67,22 @@ def test_wrap():
         segyio.tools.wrap(f.text[0])
         segyio.tools.wrap(f.text[0], 90)
 
+def test_wrap_only_stringifies_content():
+    """
+    in python2, str(text) gives the content of the text header as a byte array,
+    as a string really is a bytearray, whereas in python3 str(bytearray) gives
+    the string "bytearray(b'C 1...')".
+
+    https://github.com/equinor/segyio/issues/444
+    """
+    with segyio.open(testdata / 'small.sgy') as f:
+        s = segyio.tools.wrap(f.text[0])
+        assert s.startswith('C 1')
+
+    with segyio.open(testdata / 'small.sgy') as f:
+        s = segyio.tools.wrap(f.text[0].decode(errors = 'ignore'))
+        assert s.startswith('C 1')
+
 
 def test_values_text_header_creation():
     lines = {i + 1: chr(64 + i) * 76 for i in range(40)}


### PR DESCRIPTION
The str(text) on the input in wrap was quite broken in python3, as
str(text) actually prepends the bytearray(b'') like in repr.