### PR TITLE
Avoid end of non-void warning in test.read-size

### DIFF
--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -525,6 +525,12 @@ int field_read_size(const int field) {
          << std::hex
          << output
      );
+
+    /*
+     * fallthrough to stop warning - negative should never give a succesful
+     * test, and FAIL() should already have aborted
+     */
+    return -1;
 }
 
 }


### PR DESCRIPTION
The helper function will always return or invoke the FAIL() macro, but
gcc under certain conditions complain:

  segyio/lib/test/segy.cpp:534:1: warning: control reaches end of
  non-void function [-Wreturn-type]

If the macro for some reason is not expanded correctly and this does not
abort, negative values should never pass a test for size and at least
mark the error. When FAIL() does abort (it should), the final return is
never reached.