### PR TITLE
Revert "Install package without --record/--single"

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -89,6 +89,8 @@ install(CODE "
         COMMAND ${PYTHON_EXECUTABLE} ${setup.py}
             install
                 \${root_destdir}
+                --single-version-externally-managed
+                --record record.txt
                 --cmake-executable \"${CMAKE_COMMAND}\"
                 --generator \"${CMAKE_GENERATOR}\"
                 \${prefix}


### PR DESCRIPTION
This reverts commit 79f0863c5814a4a375ece345c1751cb6c99634f7.

This is not well enough tested before merging. CI quickly shows that
often, when using a cmake based install, a package is to be built, or
the prefix is somewhere not yet in PYTHONPATH. Setuptools opts to fail
the build in this case, and these flags turns off that behaviour. When
cmake is used to install the python package, it is to be expected that
reasonable care is taken that the prefix passed is the correct one, also
for python, and it does not make sense for setuptools to disagree with
that.