### PR TITLE
Add requirements-doc.txt, matplotlib for gallery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,9 @@ install:
         brew update && brew install cppcheck;
     fi
   - pip install -r requirements.txt
+  - pip install -r requirements-doc.txt
   - pip install setuptools setuptools-scm scikit-build
-  - pip install bandit pytest pytest-runner sphinx sphinx-gallery
+  - pip install bandit pytest pytest-runner
 
 before_script:
   - enabled="-DBUILD_PYTHON=OFF -DBUILD_MEX=OFF"

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,7 @@
+sphinx
+sphinx-gallery
+# manually grab pillow, since sphinx-gallery does not want
+# to specify their dependencies
+# https://github.com/sphinx-gallery/sphinx-gallery/issues/192
+pillow
+matplotlib

--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -1,2 +1,3 @@
 segyio
 sphinx-gallery
+matplotlib


### PR DESCRIPTION
The gallery uses matplotlib internally, but there is no direct
dependency on it. Add a new requrements-doc.txt for doc-specific
requirements for easier management.