### PR TITLE
Return single sample in f.trace[i,j] for ints

### DIFF
--- a/python/segyio/trace.py
+++ b/python/segyio/trace.py
@@ -187,6 +187,7 @@ class Trace(Sequence):
             # trace to be loaded.
             j = slice(0, self.shape, 1)
 
+        single = False
         try:
             start, stop, step = j.indices(self.shape)
         except AttributeError:
@@ -195,13 +196,15 @@ class Trace(Sequence):
             start = int(j) % self.shape
             stop = start + 1
             step = 1
+            single = True
 
         n_elements = len(range(start, stop, step))
 
         try:
             i = self.wrapindex(i)
             buf = np.zeros(n_elements, dtype = self.dtype)
-            return self.filehandle.gettr(buf, i, 1, 1, start, stop, step, n_elements)
+            tr = self.filehandle.gettr(buf, i, 1, 1, start, stop, step, n_elements)
+            return tr[0] if single else tr
         except TypeError:
             pass
 

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -270,6 +270,16 @@ def test_traces_subslicing(openfn, kwargs):
         assert np.array_equal(f.trace[0, ::-1], f.trace[0][::-1])
         assert np.array_equal(f.trace[0, ::2], f.trace[0][::2])
         # test getting single element
+
+        # should be single a single float, not an array in the case of int(i),
+        # int(j)
+        with pytest.raises(TypeError):
+            len(f.trace[0, 1])
+
+        # even length-of-one slices should give arrays
+        assert len(f.trace[0, 1:2]) == 1
+        npt.assert_array_equal(f.trace[0, 1:2], f.trace[0][1:2])
+
         assert f.trace[0, 1] == f.trace[0][1]
         assert f.trace[0, -3] == f.trace[0][-3]
 


### PR DESCRIPTION
The intention was always for f.trace[i,j] to return a single sample when
i and j were both integers:

    assert f.trace[0, 1] == f.trace[0][1]

However, this evaluated to true when [i, j] returns an array, since the
result of the comparison is array([True]), and which is not falsy.

Reported in https://github.com/equinor/segyio/issues/475