### PR TITLE
Run homebrew through addons on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ addons:
         - cppcheck
         - cmake
         - cmake-data
+    homebrew:
+      update: true
+      packages:
+        - cppcheck
 
 before_install:
     - git clone https://github.com/matthew-brett/multibuild
@@ -73,9 +77,6 @@ before_install:
     - before_install
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew update && brew install cppcheck;
-    fi
   - pip install -r requirements.txt
   - pip install -r requirements-doc.txt
   - pip install setuptools setuptools-scm scikit-build


### PR DESCRIPTION
The brew update often fails and using addons is more elegant than
manually invoking brew behind platform guards. This makes the config
simpler, and should prevent some macos job failures [1].

[1] such as https://travis-ci.org/github/equinor/segyio/jobs/731298536