### PR TITLE
Suppress cppcheck false positives

### DIFF
--- a/applications/flip-endianness.cpp
+++ b/applications/flip-endianness.cpp
@@ -154,7 +154,11 @@ int main( int argc, char** argv ) {
         std::exit( EXIT_FAILURE );
     }
 
+    // style: Argument 'std::max(3200,trsize)' to function buffer is always
+    // 3200 [knownArgument]
+    // this is just wrong, so suppress it
     std::vector< char > buffer(
+        // cppcheck-suppress knownArgument
         std::max( SEGY_TEXT_HEADER_SIZE, trsize )
     );
 

--- a/cppcheck/suppressions.txt
+++ b/cppcheck/suppressions.txt
@@ -16,3 +16,15 @@ unusedStructMember:*lib/test/segy.cpp
 // and syntax errors are not that interesting from a cppcheck point of view,
 // since the compiler handles them nicely
 syntaxError:*lib/experimental/segyio/segyio.hpp
+
+// cppcheck 2.1 (at least) does not recognize exit() properly as program
+// termination, and considers the null pointer checks redundant, or considers
+// most arrays and buffers possible null pointer dereferences. By replacing
+// exit() with return, these go away, but cppcheck starts complaining about
+// resource leaks (which are nonsensical as the return is in main).
+// At some point it should probably be rewritten to a style cppcheck accepts,
+// or cppcheck should be replaced.
+//
+// The style of code that makes these warnings happen are all application
+// oriented though, so suppressing the check there should not be too bad.
+nullPointerRedundantCheck:*applications/*.c


### PR DESCRIPTION
cppcheck v2.1 produces some false positives that would be akward or just
a lot of noise to fix. Suppress them for now, and hope that cppcheck
either fixes these cases, or rewrite the code into a style cppcheck
prefer at some later time.