### PR TITLE
Use Py_ssize_t for type-length arguments

### DIFF
--- a/python/segyio/segyio.cpp
+++ b/python/segyio/segyio.cpp
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #if defined(_DEBUG) && defined(_MSC_VER)
 #  define _CRT_NOFORCE_MAINFEST 1
 #  undef _DEBUG
@@ -1042,7 +1043,7 @@ PyObject* puttr( segyiofd* self, PyObject* args ) {
 
     int traceno;
     char* buffer;
-    int buflen;
+    Py_ssize_t buflen;
 
     if( !PyArg_ParseTuple( args, "is#", &traceno, &buffer, &buflen ) )
         return NULL;
@@ -1537,7 +1538,7 @@ PyObject* fread_trace0( PyObject* , PyObject* args ) {
     int stride;
     int offsets;
     int* indices;
-    int indiceslen;
+    Py_ssize_t indiceslen;
     char* linetype;
 
     if( !PyArg_ParseTuple( args, "iiiis#s", &lineno,


### PR DESCRIPTION
The with-length argument type specifier would be either int or
Py_ssize_t, depending on the PY_SSIZE_T_CLEAN macro being defined.

From the docs:
  For all # variants of formats (s#, y#, etc.), the type of the length
  argument (int or Py_ssize_t) is controlled by defining the macro
  PY_SSIZE_T_CLEAN before including Python.h. If the macro was defined,
  length is a Py_ssize_t rather than an int. This behavior will change
  in a future Python version to only support Py_ssize_t and drop int
  support.  It is best to always define PY_SSIZE_T_CLEAN.

https://docs.python.org/3/c-api/arg.html#arg-parsing

In python3.8, using ints for lengths (i.e. not defining
PY_SSIZE_T_CLEAN) is considered deprecated, and in future versions of
python only Py_ssize_t will be legal.

From the docs:
  It is recommended to always define PY_SSIZE_T_CLEAN before including
  Python.h. See Parsing arguments and building values for a description
  of this macro.

https://docs.python.org/3/c-api/intro.html