### PR TITLE
Prefer build-system.requires over setup_requires

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "scikit-build",
     "wheel",
     "pybind11",
+    "pytest-runner",
 ]
 
 [tool.cibuildwheel]

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -4,11 +4,5 @@ version = 1.9.7
 [aliases]
 test=pytest
 
-[options]
-setup_requires =
-    pytest-runner
-    scikit-build
-    pybind11
-
 [tool:pytest]
 python_files = test/*.py


### PR DESCRIPTION
Possibly creating issues for komodo, and is pep518 compliant.