### PR TITLE
Add missing cstdint include for GCC 13

### DIFF
--- a/python/segyio/segyio.cpp
+++ b/python/segyio/segyio.cpp
@@ -13,6 +13,7 @@
 #include <segyio/segy.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <stdexcept>
@@ -97,8 +98,8 @@ PyObject* RuntimeError( int err ) {
 template< typename T1, typename T2 >
 PyObject* RuntimeError( const char* msg, T1 t1, T2 t2 ) {
     return PyErr_Format( PyExc_RuntimeError, msg, t1, t2 );
-}    
-    
+}
+
 PyObject* IOErrno() {
     return PyErr_SetFromErrno( PyExc_IOError );
 }
@@ -844,7 +845,7 @@ struct metrics_errmsg {
                                    "or offset (%i) field", il, xl, of );
 
             case SEGY_INVALID_SORTING:
-                return RuntimeError( "unable to find sorting." 
+                return RuntimeError( "unable to find sorting."
                                     "Check iline, (%i) and xline (%i) "
                                     "in case you are sure the file is "
                                     "a 3D sorted volume", il, xl);


### PR DESCRIPTION
Without this include it gives an error on install
```
segyio-1.9.11/python/segyio/segyio.cpp:1462:30: error: ‘uint16_t’ is not a member of ‘std’; did you mean ‘wint_t’?
1462 |             value = int(std::uint16_t(value));
```