### PR TITLE
Build for macOS on macos-latest runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
             cmake_generator: "-G \"Visual Studio 16 2019\" -A x64"
           - os: windows-2019
             cmake_generator: "-G \"Visual Studio 16 2019\" -A Win32"
-          - os: macOS-10.15
+          - os: macos-latest
             privledges: "sudo"
           - os: ubuntu-20.04
             privledges: "sudo"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -23,7 +23,7 @@ jobs:
             arch: aarch64
           - os: ubuntu-20.04
             arch: i686
-          - os: macOS-10.15
+          - os: macos-latest
             arch: x86_64
 
     steps:


### PR DESCRIPTION
The macOS-10.15 runners are no longer available. Update to macos-latest runners.