### PR TITLE
Bump version tag to 1.9.12

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.9.12
+* Distribute wheels for Python 3.12
+* Distribute wheels for Apple ARM
+
 # 1.9.11
 * Fixed a bug where segyio used the Delay Recording Time without it's scaling
   factor when setting up the sample offsets on open.

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.9.11
+version = 1.9.12
 
 [aliases]
 test=pytest


### PR DESCRIPTION
PyPI recets the latest build because the metadata was not updated for the new release.

```text
[...]
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Checking artifact/segyio-1.9.11-cp39-cp39-win32.whl: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Checking artifact/segyio-1.9.11-cp39-cp39-win_amd64.whl: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Uploading distributions to https://upload.pypi.org/legacy/
Uploading segyio-1.9.11-cp310-cp310-macosx_10_9_x86_64.whl
25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/90.1 kB • --:-- • ?
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.1/90.1 kB • 00:00 • 3.9 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.1/90.1 kB • 00:00 • 3.9 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.1/90.1 kB • 00:00 • 3.9 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.1/90.1 kB • 00:00 • 3.9 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.1/90.1 kB • 00:00 • 3.9 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.1/90.1 kB • 00:00 • 3.9 MB/s
25hWARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         File already exists. See https://pypi.org/help/#file-name-reuse for    
         more information.   
```