### PR TITLE
Fix attribute error in setup.py

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
             analyzers: "cppcheck"
             scan: "scan-build --status-bugs"
             mkdoc: "-DBUILD_DOC=ON -DSPHINX_ARGS=-WT"
-          - os: macos-13-xlarge
+          - os: macos-latest
             privledges: "sudo"
             arch: arm64
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -25,7 +25,7 @@ jobs:
             arch: i686
           - os: macos-latest
             arch: x86_64
-          - os: macos-13-xlarge
+          - os: macos-latest
             arch: arm64
 
     steps:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -48,7 +48,7 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: >
             CMAKE_GENERATOR="${{ matrix.cmake_generator }}"
             CMAKE_GENERATOR_PLATFORM="${{ matrix.cmake_generator_platform }}"
-          CIBW_SKIP: pp* *-musllinux_* cp313-*
+          CIBW_SKIP: pp* *-musllinux_* cp313-* cp39-*
           CIBW_ARCHS: ${{ matrix.arch }}
         run: |
             python -m cibuildwheel --output-dir wheelhouse python/

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -53,8 +53,9 @@ jobs:
         run: |
             python -m cibuildwheel --output-dir wheelhouse python/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   publish:
@@ -65,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
 
       - name: Publish wheels to PyPI
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -48,7 +48,7 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: >
             CMAKE_GENERATOR="${{ matrix.cmake_generator }}"
             CMAKE_GENERATOR_PLATFORM="${{ matrix.cmake_generator_platform }}"
-          CIBW_SKIP: pp* *-musllinux_*
+          CIBW_SKIP: pp* *-musllinux_* cp313-*
           CIBW_ARCHS: ${{ matrix.arch }}
         run: |
             python -m cibuildwheel --output-dir wheelhouse python/

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -23,7 +23,9 @@ jobs:
             arch: aarch64
           - os: ubuntu-20.04
             arch: i686
-          - os: macos-latest
+          # macos-latest runs on arm64 architecture and cibuildwheel cross
+          # compiling for x86_64 fails
+          - os: macos-13
             arch: x86_64
           - os: macos-latest
             arch: arm64

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -166,8 +166,8 @@ def open(filename, mode="r", iline = 189,
     f = segyio.SegyFile(fd,
             filename = str(filename),
             mode = mode,
-            iline = iline,
-            xline = xline,
+            iline = int(iline),
+            xline = int(xline),
             endian = endian,
     )
 
@@ -189,4 +189,4 @@ def open(filename, mode="r", iline = 189,
     if ignore_geometry:
         return f
 
-    return infer_geometry(f, metrics, iline, xline, strict)
+    return infer_geometry(f, metrics, int(iline), int(xline), strict)

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,7 +95,6 @@ skbuild.setup(
         # supported OS X release 10.9
         '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9',
     ],
-    cmdclass = { 'test': setuptools.command.test.test },
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Other Environment',

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -540,10 +540,10 @@ def read_line(f, metrics, iline_idx, xline_idx):
     buf = numpy.zeros((len(iline_idx), samples), dtype=numpy.single)
 
     f.getline(xline_trace0, len(iline_idx), xline_stride, offsets, buf)
-    assert sum(sum(buf)) == approx(800.061169624, abs=1e-6)
+    assert sum(sum(buf), numpy.double(0)) == approx(800.061169624, abs=1e-6)
 
     f.getline(iline_trace0, len(xline_idx), iline_stride, offsets, buf)
-    assert sum(sum(buf)) == approx(305.061146736, abs=1e-6)
+    assert sum(sum(buf), numpy.double(0)) == approx(305.061146736, abs=1e-6)
 
     f.close()
 


### PR DESCRIPTION
This line was causing a  error due to an update to scikit-build.  The issue was that the setuptools.command.test module is not put into the symbol table by the setuptools import, but it was put there during the skbuild import causing it to be available. Due to changes in scikit-build this is no longer the case and the line gives an AttributError.

The rationale for this line was that scikit-builds test command implied develop (this was obnoxious), something that is no longer true. There is thus no longer any reason to keep this line, so we can fix this issue by simply removing it.