### PR TITLE
Add maximum version for setuptools to avoid `test` attribute not being available

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 40",
+    "setuptools >= 40, < 42",
     "scikit-build",
     "wheel",
     "pybind11",


### PR DESCRIPTION
Set a maximum version for setuptools to avoid `AttributeError: module 'setuptools.command' has no attribute 'test' error`
I have found that the problem start from setuptools version 42
Related to #575 