### PR TITLE
Bring back old readthedocs look

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.imgmath',
     'sphinx_gallery.gen_gallery',
+    'sphinx_rtd_theme',
 ]
 
 autosummary_generate = True
@@ -155,6 +156,10 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Create table of contents entries for domain objects (e.g. functions, classes,
+# attributes, etc.). Default is True.
+toc_object_entries = False
+
 # -- Options for Sphinx Gallery output ----------------------------------------------
 sphinx_gallery_conf = {
     # path to your examples scripts
@@ -179,7 +184,7 @@ sphinx_gallery_conf = {
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -1,3 +1,4 @@
 segyio
 sphinx-gallery
 matplotlib
+sphinx-rtd-theme


### PR DESCRIPTION
Looks like after fixing readthedocs builds we need to specify the theme explicitly.

Also sphinx got updated. In new version content tree doesn't look the same anymore and is cluttered with domain objects. This new feature needs to be turned off to look the same as before.

Currently:
<img src="https://github.com/user-attachments/assets/056cf389-f127-4038-9574-89d239567515" width="50%"/>

Before:
<img src="https://github.com/user-attachments/assets/8af96e80-b3f2-444d-826c-5cce69624a3d" width="50%"/>

With this PR:
<img src="https://github.com/user-attachments/assets/76ce9a0a-b469-4fbb-867e-3fb43685f16e" width="50%"/>