### PR TITLE
Add benchmark tests

### DIFF
--- a/.github/actions/benchmark/action.yaml
+++ b/.github/actions/benchmark/action.yaml
@@ -1,0 +1,82 @@
+name: Benchmark
+description: benchmark execution
+
+inputs:
+  ref:
+    description: ref to checkout
+  compare:
+    description: results comparison string
+    default: --benchmark-compare=0001 --benchmark-compare-fail=min:25% --benchmark-group-by=fullname --color=yes
+
+runs:
+  using: "composite"
+  steps:
+    - name: Print available disk space
+      shell: bash
+      run: df -h
+
+    - name: Checkout commit which performance should be measured
+      shell: bash
+      run: |
+        git fetch origin ${{ inputs.ref }} --depth 1
+        git checkout ${{ inputs.ref }}
+
+    - name: Configure
+      shell: bash
+      run: |
+        cmake -S . -B build \
+          -DBUILD_PYTHON=ON \
+          -DBUILD_SHARED_LIBS=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+
+    - name: Build and Install
+      shell: bash
+      run: |
+        cmake \
+          --build build \
+          --config Release \
+
+    - name: Set PYTHONPATH
+      shell: bash
+      run: echo "PYTHONPATH=$(pwd)/python" >> $GITHUB_ENV
+
+    - name: Checkout current commit which contains all tests to run
+      shell: bash
+      run: git checkout ${{ github.sha }}
+
+    - name: Make segy file
+      shell: bash
+      working-directory: python
+      run: |
+        if [ ! -f file.sgy ]; then
+          time python -m examples.make-file file.sgy 1400 1 1000 1 600
+        else
+          echo "file.sgy already exists"
+        fi
+
+    - name: Make segy pre-stack file
+      shell: bash
+      working-directory: python
+      run: |
+        if [ ! -f file-ps.sgy ]; then
+          time python -m examples.make-ps-file file-ps.sgy 1400 1 500 1 600 1 3
+        else
+          echo "file-ps.sgy already exists"
+        fi
+
+    - name: Print filesize
+      shell: bash
+      working-directory: python
+      run: |
+        ls -lh file.sgy
+        ls -lh file-ps.sgy
+
+    - name: Run benchmark tests
+      shell: bash
+      working-directory: python
+      run: |
+        pytest test/benchmarks.py --benchmark-sort=name --benchmark-autosave ${{ inputs.compare }}
+
+    - name: Remove build artifacts
+      shell: bash
+      run: git clean -df --exclude=.benchmarks

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,44 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      commit_ref:
+        description: "optional: compare to specific ref"
+        required: false
+
+jobs:
+  benchmarks:
+    name: Benchmark scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build/test dependencies
+        shell: bash
+        working-directory: python
+        run: |
+          python3 -m pip install -r requirements-dev.txt
+
+      - name: Set default benchmark reference
+        run: echo "BENCHMARK_REF=142e45a2b941a1b603723c38882b193db1c1d968" >> $GITHUB_ENV
+
+      - name: Set benchmark reference if defined by workflow_dispatch
+        if: github.event.inputs.commit_ref != ''
+        run: echo "BENCHMARK_REF=${{ github.event.inputs.commit_ref }}" >> $GITHUB_ENV
+
+      - name: Benchmark old commit
+        uses: "./.github/actions/benchmark"
+        with:
+          ref: ${{ env.BENCHMARK_REF }}
+          compare: ""
+
+      - name: Benchmark current commit and compare
+        uses: "./.github/actions/benchmark"
+        with:
+          ref: ${{ github.sha }}

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,0 +1,4 @@
+numpy
+scikit-build
+pytest
+pytest-benchmark

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -6,3 +6,4 @@ test=pytest
 
 [tool:pytest]
 python_files = test/*.py
+addopts = --ignore=test/benchmarks.py

--- a/python/test/benchmarks.py
+++ b/python/test/benchmarks.py
@@ -1,0 +1,92 @@
+# Benchmarking suite, not run by default with pytest.
+# To run this file pytest-benchmark must be installed via pip.
+
+import os
+import shutil
+import segyio
+import pytest
+
+
+# Files are expected to be present at the run location
+# Files size should be compatible with retrieved lines
+files = [
+    'file.sgy',
+    'file-ps.sgy'
+]
+
+
+def mmap(f):
+    f.mmap()
+
+
+def run(filepath, mmap, func):
+    with segyio.open(filepath) as f:
+        if mmap:
+            f.mmap()
+        func(f)
+
+
+def iline_slice(f):
+    f.iline[200]
+
+
+def xline_slice(f):
+    f.xline[300]
+
+
+def depth_slice(f):
+    f.depth_slice[1000]
+
+
+def cube(filepath):
+    segyio.tools.cube(filepath)
+
+
+def change_data(output_file):
+    # multiply data by 2
+    with segyio.open(output_file, "r+") as f:
+        for i in f.ilines:
+            f.iline[i] = 2 * f.iline[i]
+
+
+slices = [
+    iline_slice,
+    xline_slice,
+    depth_slice,
+]
+
+
+@pytest.mark.benchmark(group="nommap")
+@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("func", slices)
+def test_read_speed(benchmark, file, func):
+    benchmark(run, file, False, func)
+
+
+@pytest.mark.benchmark(group="with mmap")
+@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("func", slices)
+def test_mmap_read_speed(benchmark, file, func):
+    benchmark(run, file, True, func)
+
+
+@pytest.mark.benchmark(group="cube")
+@pytest.mark.parametrize("file", files)
+def test_cube_speed(benchmark, file):
+    benchmark.pedantic(run, rounds=15, args=[file, False, cube])
+
+
+@pytest.mark.benchmark(group="write")
+@pytest.mark.parametrize("file", files)
+def test_write_file(benchmark, file, tmp_path):
+    output_file = tmp_path / 'output.sgy'
+
+    def setup():
+        if os.path.exists(output_file):
+            os.remove(output_file)
+        shutil.copyfile(file, output_file)
+
+    benchmark.pedantic(change_data, setup=setup, rounds=5, args=[output_file])
+
+    if os.path.exists(output_file):
+        os.remove(output_file)


### PR DESCRIPTION
Tests are not run by default, need to specifically run `pytest test/benchmarks.py` to trigger.

I reduced file size even more, so it is now around 3GB. Not sure anymore it helped though.

Out of last 10 attempts 1 [already flopped](https://github.com/achaikou/segyio/actions/runs/13310423399/job/37172257016). For the whole run all tests were1.25x- 2x times slower than usual.

So it probably mostly depends on current workload of the machine we are getting. Figuring out how to get dedicated machine just for this is too much, I think.

So maybe we want to remove running this for pull request / push to master?
Automatically re-running the job in case of failure isn't straightforward, so we'll have to retry manually if something is off.