### PR TITLE
Fix declaration without a prototype warning

### DIFF
--- a/applications/segyio-catb.c
+++ b/applications/segyio-catb.c
@@ -9,7 +9,7 @@
 #include "apputils.h"
 #include <segyio/segy.h>
 
-static int printhelp(){
+static int printhelp(void){
     puts( "Usage: segyio-catb [OPTION]... [FILE]...\n"
           "Concatenate the binary header from FILE(s) to seismic unix "
           "output.\n"

--- a/applications/segyio-cath.c
+++ b/applications/segyio-cath.c
@@ -9,7 +9,7 @@
 #include "apputils.c"
 #include <segyio/segy.h>
 
-static int help() {
+static int help(void) {
     puts( "Usage: segyio-cath [OPTION]... [FILE]...\n"
           "Concatenate the textual header(s) from FILE(s) to standard output.\n"
           "\n"

--- a/applications/segyio-catr.c
+++ b/applications/segyio-catr.c
@@ -395,7 +395,7 @@ static const char* desc[91] = {
     "Unassigned 2"
 };
 
-static int help() {
+static int help(void) {
     puts(
 "Usage: segyio-catr [OPTION]... FILE\n"
 "Print specific trace headers from FILE\n"

--- a/applications/segyio-crop.c
+++ b/applications/segyio-crop.c
@@ -10,7 +10,7 @@
 #include "apputils.c"
 #include <segyio/segy.h>
 
-static int help() {
+static int help(void) {
     puts( "Usage: segyio-crop [OPTION]... SRC DST\n"
           "Copy a sub cube from SRC to DST\n"
           "\n"


### PR DESCRIPTION
During compiling the functions without parameter definition gives warnings. 