### PR TITLE
Use 64 bits to read and write field

### DIFF
--- a/applications/apputils.c
+++ b/applications/apputils.c
@@ -36,7 +36,7 @@ int parseint( const char* str, int* x ) {
 }
 
 int bfield( const char* header, int field ) {
-    int32_t f;
+    int64_t f;
     int err = segy_get_bfield( header, field, &f );
 
     if( err ) return -1;
@@ -44,7 +44,7 @@ int bfield( const char* header, int field ) {
 }
 
 int trfield( const char* header, int field ) {
-    int32_t f;
+    int64_t f;
     int err = segy_get_field( header, field, &f );
 
     if( err ) return -1;

--- a/applications/segyinfo.c
+++ b/applications/segyinfo.c
@@ -7,16 +7,16 @@
 #include <segyio/segy.h>
 
 static void printSegyTraceInfo( const char* buf ) {
-    int cdp, tsf, xl, il;
+    int64_t cdp, tsf, xl, il;
     segy_get_field( buf, SEGY_TR_ENSEMBLE, &cdp );
     segy_get_field( buf, SEGY_TR_SEQ_FILE, &tsf );
     segy_get_field( buf, SEGY_TR_CROSSLINE, &xl );
     segy_get_field( buf, SEGY_TR_INLINE, &il );
 
-    printf("cdp:               %d\n", cdp );
-    printf("TraceSequenceFile: %d\n", tsf );
-    printf("Crossline3D:       %d\n", xl );
-    printf("Inline3D:          %d\n", il );
+    printf("cdp:               %lld\n", cdp );
+    printf("TraceSequenceFile: %lld\n", tsf );
+    printf("Crossline3D:       %lld\n", xl );
+    printf("Inline3D:          %lld\n", il );
 }
 
 #define minimum(x,y) ((x) < (y) ? (x) : (y))
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
     const int samples = segy_samples( header );
     const long trace0 = segy_trace0( header );
     const int trace_bsize = segy_trace_bsize( samples );
-    int extended_headers;
+    int64_t extended_headers;
     err = segy_get_bfield( header, SEGY_BIN_EXT_HEADERS, &extended_headers );
 
     if( err != 0 ) {
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
     printf( "Sample format: %d\n", format );
     printf( "Samples per trace: %d\n", samples );
     printf( "Traces: %d\n", traces );
-    printf("Extended text header count: %d\n", extended_headers );
+    printf("Extended text header count: %lld\n", extended_headers );
     puts("");
 
 
@@ -113,7 +113,7 @@ int main(int argc, char* argv[]) {
             exit( err );
         }
 
-        int sample_count;
+        int64_t sample_count;
         err = segy_get_field( traceh, SEGY_TR_SAMPLE_COUNT, &sample_count );
 
         if( err != 0 ) {

--- a/applications/segyio-catb.c
+++ b/applications/segyio-catb.c
@@ -24,7 +24,7 @@ static int printhelp(){
 }
 
 static int get_binary_value( char* binheader, int bfield ){
-    int32_t f;
+    int64_t f;
     segy_get_bfield( binheader, bfield, &f );
 
     /*
@@ -34,7 +34,7 @@ static int get_binary_value( char* binheader, int bfield ){
     switch (bfield) {
         case SEGY_BIN_SAMPLES:
         case SEGY_BIN_SAMPLES_ORIG:
-            f = (int32_t)((uint16_t)(f));
+            f = (int64_t)((int32_t)((uint16_t)(f)));
             break;
     }
     return f;
@@ -211,19 +211,19 @@ int main( int argc, char** argv ){
         if( err ) return errmsg(opterr, "Unable to read binary header"); 
 
         for( int c = 0; c < 30; ++c ){
-            int field = get_binary_value( binheader, bfield_value[ c ] );
+            uint64_t field = get_binary_value( binheader, bfield_value[ c ] );
             if( opts.nonzero && !field) continue;
 
             if( opts.description ) {
                 int byte_offset = (bfield_value[ c ] - SEGY_TEXT_HEADER_SIZE);
-                printf( "%s\t%d\t%d\t%s\n",
+                printf( "%s\t%llu\t%d\t%s\n",
                     su[ c ],
                     field,
                     byte_offset,
                     su_desc[ c ] );
             }
             else
-                printf( "%s\t%d\n", su[ c ], field );
+                printf( "%s\t%lld\n", su[ c ], field );
         }
         segy_close( fp );
     }

--- a/applications/segyio-cath.c
+++ b/applications/segyio-cath.c
@@ -34,7 +34,7 @@ static int ext_headers( segy_file* fp ) {
 
     if( err ) return -1;
 
-    int32_t ext;
+    int64_t ext;
     err = segy_get_bfield( binary, SEGY_BIN_EXT_HEADERS, &ext );
     if( err ) return -2;
     return ext;

--- a/applications/segyio-catr.c
+++ b/applications/segyio-catr.c
@@ -694,7 +694,7 @@ int main( int argc, char** argv ) {
                 exit( errmsg( errno, "Unable to read trace header" ) );
 
             for( int j = 0; j < 91; j++ ) {
-                int f;
+                int64_t f;
                 segy_get_field( trheader, fields[j], &f );
                 if( opts.nonzero && !f ) continue;
 
@@ -709,14 +709,14 @@ int main( int argc, char** argv ) {
                 }
 
                 if( opts.description ) {
-                    printf( "%s\t%d\t%d\t%s\n",
+                    printf( "%s\t%lld\t%d\t%s\n",
                             labels[j],
                             f,
                             fields[ j ],
                             desc[ j ] );
                 }
                 else
-                    printf( "%s\t%d\n", labels[j], f );
+                    printf( "%s\t%lld\n", labels[j], f );
             }
         }
     }

--- a/lib/experimental/segyio/segyio.hpp
+++ b/lib/experimental/segyio/segyio.hpp
@@ -1316,7 +1316,7 @@ binary_header binary_header_reader< Derived >::get_bin() noexcept(false) {
     }
 
     const auto getb = [&]( int key ) {
-        int32_t f;
+        int64_t f;
         segy_get_bfield( buffer, key, &f );
         return f;
     };
@@ -1381,7 +1381,7 @@ trace_header trace_header_reader< Derived >::get_th( int i ) noexcept(false) {
     }
 
     const auto getf = [&]( int key ) {
-        int32_t f;
+        int64_t f;
         segy_get_field( buffer, key, &f );
         return f;
     };

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -87,10 +87,10 @@ int segy_format( const char* binheader );
  */
 int segy_set_format( segy_file*, int format );
 
-int segy_get_field( const char* traceheader, int field, int32_t* f );
-int segy_get_bfield( const char* binheader, int field, int32_t* f );
-int segy_set_field( char* traceheader, int field, int32_t val );
-int segy_set_bfield( char* binheader, int field, int32_t val );
+int segy_get_field( const char* traceheader, int field, int64_t* f );
+int segy_get_bfield( const char* binheader, int field, int64_t* f );
+int segy_set_field( char* traceheader, int field, int64_t val );
+int segy_set_bfield( char* binheader, int field, int64_t val );
 
 int segy_field_forall( segy_file*,
                        int field,

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -258,7 +258,7 @@ TEST_CASE_METHOD( smallbin,
                   "use bin-interval when trace-interval is zero",
                   "[c.segy]" ) {
 
-    std::int32_t hdt = arbitrary_int();
+    std::int64_t hdt = arbitrary_int();
     segy_get_bfield( bin, SEGY_BIN_INTERVAL, &hdt );
     REQUIRE( hdt == 4000 );
 
@@ -389,7 +389,7 @@ TEST_CASE_METHOD( smallheader,
                   "valid trace-header fields can be read",
                   "[c.segy]" ) {
 
-    int32_t ilno;
+    int64_t ilno;
     Err err = segy_get_field( header, SEGY_TR_INLINE, &ilno );
     CHECK( success( err ) );
     CHECK( ilno == 1 );
@@ -398,7 +398,7 @@ TEST_CASE_METHOD( smallheader,
 TEST_CASE_METHOD( smallheader,
                   "zero header field is an argument error",
                   "[c.segy]" ) {
-    const int32_t input_value = arbitrary_int();
+    const int64_t input_value = arbitrary_int();
     auto value = input_value;
     Err err = segy_get_field( header, 0, &value );
 
@@ -409,7 +409,7 @@ TEST_CASE_METHOD( smallheader,
 TEST_CASE_METHOD( smallheader,
                   "negative header field is an argument error",
                   "[c.segy]" ) {
-    const int32_t input_value = arbitrary_int();
+    const int64_t input_value = arbitrary_int();
     auto value = input_value;
     Err err = segy_get_field( header, -1, &value );
 
@@ -420,7 +420,7 @@ TEST_CASE_METHOD( smallheader,
 TEST_CASE_METHOD( smallheader,
                   "unaligned header field is an argument error",
                   "[c.segy]" ) {
-    const int32_t input_value = arbitrary_int();
+    const int64_t input_value = arbitrary_int();
     auto value = input_value;
     Err err = segy_get_field( header, SEGY_TR_INLINE + 1, &value );
 
@@ -431,7 +431,7 @@ TEST_CASE_METHOD( smallheader,
 TEST_CASE_METHOD( smallheader,
                   "too large header field is an argument error",
                   "[c.segy]" ) {
-    const int32_t input_value = arbitrary_int();
+    const int64_t input_value = arbitrary_int();
     auto value = input_value;
     Err err = segy_get_field( header, SEGY_TRACE_HEADER_SIZE + 10, &value );
 
@@ -513,7 +513,7 @@ int field_read_size(const int field) {
     std::array< char, size > header;
     header.fill(0x01);
 
-    int output;
+    int64_t output;
     segy_get_field(header.data(), field, &output);
 
     if (output == 0x0101)     return 2;
@@ -1300,7 +1300,7 @@ TEST_CASE( "setting correct header fields succeeds",
     CHECK( success( err ) );
 
 
-    int32_t output;
+    int64_t output;
     err = segy_get_field( header, field, &output );
     CHECK( success( err ) );
 
@@ -1325,8 +1325,8 @@ SCENARIO( "modifying trace header", "[c.segy]" ) {
         CHECK( err == Err::ok() );
 
         THEN( "the header buffer is updated") {
-            int ilno = 0;
-            int scale = 0;
+            int64_t ilno = 0;
+            int64_t scale = 0;
             err = segy_get_field( header, SEGY_TR_INLINE, &ilno );
             CHECK( err == Err::ok() );
             err = segy_get_field( header, SEGY_TR_SOURCE_GROUP_SCALAR, &scale );
@@ -1355,8 +1355,8 @@ SCENARIO( "modifying trace header", "[c.segy]" ) {
 
         THEN( "changes are observable on disk" ) {
             char fresh[ SEGY_TRACE_HEADER_SIZE ] = {};
-            int ilno = 0;
-            int scale = 0;
+            int64_t ilno = 0;
+            int64_t scale = 0;
             err = segy_traceheader( fp, 5, fresh, trace0, trace_bsize );
             CHECK( err == Err::ok() );
             err = segy_get_field( fresh, SEGY_TR_INLINE, &ilno );
@@ -1824,14 +1824,14 @@ SCENARIO( "reading a 2-byte int file", "[c.segy][2-byte]" ) {
             err = segy_traceheader( fp, 0, buf, trace0, trace_bsize );
             CHECK( err == Err::ok() );
 
-            int ilno = 0;
+            int64_t ilno = 0;
             err = segy_get_field( buf, SEGY_TR_INLINE, &ilno );
             CHECK( err == Err::ok() );
             CHECK( ilno == 111 );
         }
 
         GIVEN( "an invalid field" ) {
-            int x = -1;
+            int64_t x = -1;
             err = segy_get_field( buf, SEGY_TRACE_HEADER_SIZE + 10, &x );
             CHECK( err == Err::field() );
             CHECK( x == -1 );
@@ -1977,8 +1977,8 @@ TEST_CASE("1-byte header words are correctly read", "[c.segy]") {
     header[300] = 0x01;
     header[301] = 0x02;
 
-    std::int32_t one;
-    std::int32_t two;
+    std::int64_t one;
+    std::int64_t two;
 
     Err err = segy_get_bfield(header.data(), SEGY_BIN_SEGY_REVISION, &one);
     CHECK(err == Err::ok());

--- a/mex/segy_get_bfield_mex.c
+++ b/mex/segy_get_bfield_mex.c
@@ -12,7 +12,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     const char* bin = mxGetData( prhs[ 0 ] );
     const int field = mxGetScalar( prhs[ 1 ] );
-    int f;
+    int64_t f;
 
     int err = segy_get_bfield( bin, field, &f );
 

--- a/mex/segy_get_field_mex.c
+++ b/mex/segy_get_field_mex.c
@@ -12,7 +12,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     const char* bin = mxGetData( prhs[ 0 ] );
     const int field = mxGetScalar( prhs[ 1 ] );
-    int f;
+    int64_t f;
 
     int err = segy_get_field( bin, field, &f );
 

--- a/mex/segy_get_traces_mex.c
+++ b/mex/segy_get_traces_mex.c
@@ -63,7 +63,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     segy_to_native( fmt.format, bufsize, mxGetData( plhs[ 0 ] ) );
 
-    int interval;
+    int64_t interval;
     segy_get_bfield( binary, SEGY_BIN_INTERVAL, &interval );
     plhs[ 1 ] = mxCreateDoubleScalar( interval );
     plhs[ 2 ] = mxCreateDoubleScalar( fmt.format );

--- a/python/segyio/segyio.cpp
+++ b/python/segyio/segyio.cpp
@@ -497,7 +497,7 @@ PyObject* suopen( segyiofd* self, PyObject* args ) {
     if( err )
         return IOError( "unable to read first trace header in SU file" );
 
-    int32_t f;
+    int64_t f;
     segy_get_field( header, SEGY_TR_SAMPLE_COUNT, &f );
 
     const long trace0 = 0;
@@ -1446,7 +1446,7 @@ PyObject* getfield( PyObject*, PyObject *args ) {
         buffer.len() != SEGY_TRACE_HEADER_SIZE )
         return BufferError( "buffer too small" );
 
-    int value = 0;
+    int64_t value = 0;
     int err = buffer.len() == segy_binheader_size()
             ? segy_get_bfield( buffer.buf< const char >(), field, &value )
             : segy_get_field(  buffer.buf< const char >(), field, &value )


### PR DESCRIPTION
To prepare for the new 8-bytes fields in the binary header the field get and set methods are updated to use int64_t.