### PR TITLE
Suppress cppcheck exceptions

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -9,14 +9,22 @@ on:
 
 jobs:
   cppcheck:
-    runs-on: ubuntu-latest
+    name: cppcheck on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cppcheck_install_command: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install cppcheck
+          - os: macos-latest
+            cppcheck_install_command: brew install cppcheck
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install cppcheck
+          ${{ matrix.cppcheck_install_command }}
 
       - name: Configure
         run: |
@@ -34,8 +42,9 @@ jobs:
             --suppressions-list=cppcheck/suppressions.txt   \
             --inline-suppr                                  \
             --project=build/compile_commands.json           \
-            --error-exitcode=1
-
+            --error-exitcode=1                              \
+            --check-level=exhaustive
+  
   scan_build:
     runs-on: ubuntu-latest
     steps:

--- a/lib/experimental/segyio/segyio.hpp
+++ b/lib/experimental/segyio/segyio.hpp
@@ -429,6 +429,7 @@ public:
     explicit
     basic_file( const segyio::path& path,
                 const segyio::config& cfg = config() ) noexcept(false)
+    // cppcheck-suppress internalAstError
     : Traits< basic_file >( {} ) ... {
 
         this->consider( path );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -659,6 +659,7 @@ typedef enum {
     SEGY_MMAP_INVALID,
     SEGY_READONLY,
     SEGY_NOTFOUND,
+    SEGY_MEMORY_ERROR,
 } SEGY_ERROR;
 
 #ifdef __cplusplus

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -1031,7 +1031,7 @@ static int mmapread( void* dest, const segy_file* fp, const void* src, size_t n 
     return SEGY_OK;
 }
 
-static int mmapwrite( segy_file* fp, void* dest, const void* src, size_t n ) {
+static int mmapwrite( const segy_file* fp, void* dest, const void* src, size_t n ) {
     const void* begin = fp->addr;
     const void* end = (const char*)fp->addr + fp->fsize;
     const void* destend = (const char*)dest + n;
@@ -2039,6 +2039,7 @@ int segy_readsubtr( segy_file* fp,
      */
     void* tracebuf = rangebuf ? rangebuf : malloc( elems * elemsize );
 
+    if (!tracebuf) return SEGY_MEMORY_ERROR;
     const int readc = (int) fread( tracebuf, elemsize, elems, fp->fp );
     if( readc != elems ) {
         if( !rangebuf ) free( tracebuf );
@@ -2113,6 +2114,8 @@ int segy_writesubtr( segy_file* fp,
      */
     if( !fp->addr && (step == 1 || step == -1) && fp->lsb ) {
         void* tracebuf = rangebuf ? rangebuf : malloc( elems * elemsize );
+
+        if (!tracebuf) return SEGY_MEMORY_ERROR;
         memcpy( tracebuf, buf, elemsize * elems );
 
         if (step == -1) reverse(tracebuf, elems, elemsize);
@@ -2172,6 +2175,7 @@ int segy_writesubtr( segy_file* fp,
     void* tracebuf = rangebuf ? rangebuf : malloc( elems * elemsize );
 
     // like in readsubtr, read a larger chunk and then step through that
+    if (!tracebuf) return SEGY_MEMORY_ERROR;
     const int readc = (int) fread( tracebuf, elemsize, elems, fp->fp );
     if( readc != elems ) { free( tracebuf ); return SEGY_FREAD_ERROR; }
     /* rewind, because fread advances the file pointer */


### PR DESCRIPTION
The objective is to run cppcheck during rebase testing. Adding suppress comments such that the codebase can pass without error or warning flags being raised. 