### PR TITLE
Using datatype when reading fields instead of byte size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(segyio LANGUAGES C CXX)
 
 include(CheckFunctionExists)

--- a/external/catch2/CMakeLists.txt
+++ b/external/catch2/CMakeLists.txt
@@ -1,12 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.11)
 project(catch2 CXX)
 
-# Dummy source file added because INTERFACE type
-# library is not available in CMake 2.8.12
-# it's STATIC, because MSVC would otherwise not generate a .lib file, making
-# "linking" (for header path) fail later
-#
-# TODO: when cmake minimum version is bumped to 3.x series, replace with
-# an INTERFACE library
-add_library(catch2 STATIC dummy.cpp)
-target_include_directories(catch2 SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(catch2 INTERFACE)
+target_include_directories(catch2 SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(libsegyio C CXX)
 
 set(SEGYIO_LIB_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "")

--- a/lib/experimental/segyio/segyio.hpp
+++ b/lib/experimental/segyio/segyio.hpp
@@ -426,6 +426,7 @@ public:
     explicit
     basic_file( const segyio::path& path,
                 const segyio::config& cfg = config() ) noexcept(false)
+    // cppcheck-suppress internalAstError
     : Traits< basic_file >( {} ) ... {
 
         this->consider( path );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -34,6 +34,11 @@ extern "C" {
 struct segy_file_handle;
 typedef struct segy_file_handle segy_file;
 
+typedef struct {
+    uint64_t buffer;
+    uint8_t type;
+} FieldData;
+
 segy_file* segy_open( const char* path, const char* mode );
 int segy_mmap( segy_file* );
 int segy_flush( segy_file*, bool async );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -450,6 +450,27 @@ int segy_crossline_stride( int sorting,
                            int crossline_count,
                            int* stride );
 
+
+typedef enum {
+    SEGY_IBM_FLOAT_4_BYTE = 1,
+    SEGY_SIGNED_INTEGER_4_BYTE = 2,
+    SEGY_SIGNED_SHORT_2_BYTE = 3,
+    SEGY_FIXED_POINT_WITH_GAIN_4_BYTE = 4, // Obsolete
+    SEGY_IEEE_FLOAT_4_BYTE = 5,
+    SEGY_IEEE_FLOAT_8_BYTE = 6,
+    SEGY_SIGNED_CHAR_3_BYTE = 7,
+    SEGY_SIGNED_INTEGER_3_BYTE = 7,
+    SEGY_SIGNED_CHAR_1_BYTE = 8,
+    SEGY_SIGNED_INTEGER_8_BYTE = 9,
+    SEGY_UNSIGNED_INTEGER_4_BYTE = 10,
+    SEGY_UNSIGNED_SHORT_2_BYTE = 11,
+    SEGY_UNSIGNED_INTEGER_8_BYTE = 12,
+    SEGY_UNSIGNED_INTEGER_3_BYTE = 15,
+    SEGY_UNSIGNED_CHAR_1_BYTE = 16,
+    SEGY_NOT_IN_USE_1 = 19,
+    SEGY_NOT_IN_USE_2 = 20,
+} SEGY_FORMAT;
+
 typedef enum {
     SEGY_TR_SEQ_LINE                = 1,
     SEGY_TR_SEQ_FILE                = 5,
@@ -586,25 +607,6 @@ typedef enum {
     SEGY_BIN_UNASSIGNED2            = 3507,
 } SEGY_BINFIELD;
 
-typedef enum {
-    SEGY_IBM_FLOAT_4_BYTE = 1,
-    SEGY_SIGNED_INTEGER_4_BYTE = 2,
-    SEGY_SIGNED_SHORT_2_BYTE = 3,
-    SEGY_FIXED_POINT_WITH_GAIN_4_BYTE = 4, // Obsolete
-    SEGY_IEEE_FLOAT_4_BYTE = 5,
-    SEGY_IEEE_FLOAT_8_BYTE = 6,
-    SEGY_SIGNED_CHAR_3_BYTE = 7,
-    SEGY_SIGNED_INTEGER_3_BYTE = 7,
-    SEGY_SIGNED_CHAR_1_BYTE = 8,
-    SEGY_SIGNED_INTEGER_8_BYTE = 9,
-    SEGY_UNSIGNED_INTEGER_4_BYTE = 10,
-    SEGY_UNSIGNED_SHORT_2_BYTE = 11,
-    SEGY_UNSIGNED_INTEGER_8_BYTE = 12,
-    SEGY_UNSIGNED_INTEGER_3_BYTE = 15,
-    SEGY_UNSIGNED_CHAR_1_BYTE = 16,
-    SEGY_NOT_IN_USE_1 = 19,
-    SEGY_NOT_IN_USE_2 = 20,
-} SEGY_FORMAT;
 
 typedef enum {
     SEGY_MSB = 0,

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -37,7 +37,7 @@ typedef struct segy_file_handle segy_file;
 typedef struct {
     uint64_t buffer;
     uint8_t type;
-} FieldData;
+} field_data;
 
 segy_file* segy_open( const char* path, const char* mode );
 int segy_mmap( segy_file* );

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -94,6 +94,8 @@ int segy_set_format( segy_file*, int format );
  */
 int segy_set_endianness( segy_file*, int opt );
 
+int fd_get_int( const field_data* fd, int* val );
+
 int segy_get_field( const char* traceheader, int field, int32_t* f );
 int segy_get_bfield( const char* binheader, int field, int32_t* f );
 int segy_set_field( char* traceheader, int field, int32_t val );

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -747,7 +747,7 @@ no_mmap:
 static int get_field( const char* header,
                       const uint8_t* table,
                       int field,
-                      FieldData* fd) {
+                      field_data* fd) {
     fd->type = table[ field ];
 
     fd->buffer = 0;
@@ -782,7 +782,7 @@ int segy_get_field( const char* traceheader, int field, int* f ) {
     if( field < 0 || field >= SEGY_TRACE_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    FieldData fd;
+    field_data fd;
     int err = get_field( traceheader, tr_field_type, field, &fd );
     if ( err != SEGY_OK ) return err;
     *f = (int)fd.buffer;
@@ -795,7 +795,7 @@ int segy_get_bfield( const char* binheader, int field, int32_t* f ) {
     if( field < 0 || field >= SEGY_BINARY_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    FieldData fd;
+    field_data fd;
     int err = get_field( binheader, bin_field_type, field, &fd );
     if ( err != SEGY_OK ) return err;
     *f = (int32_t)fd.buffer;
@@ -925,7 +925,7 @@ int segy_field_forall( segy_file* fp,
         for( int i = start; slicelen > 0; i += step, ++buf, --slicelen ) {
             segy_seek( fp, i, trace0, trace_bsize );
 
-            FieldData fd;
+            field_data fd;
             err = get_field( fp->cur, tr_field_type, field, &fd );
             if( err != 0 ) return err;
             if (lsb) fd.buffer = bswap_header_word(fd.buffer, formatsize( fd.type ));
@@ -952,7 +952,7 @@ int segy_field_forall( segy_file* fp,
         size_t readc = fread( header + zfield, sizeof(uint32_t), 1, fp->fp );
         if( readc != 1 ) return SEGY_FREAD_ERROR;
 
-        FieldData fd;
+        field_data fd;
         err = get_field( header, tr_field_type, field, &fd );
         if( err != 0 ) return err;
         if (lsb) fd.buffer = bswap_header_word((int32_t)fd.buffer, formatsize( fd.type ));

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -319,7 +319,148 @@ static int field_size[SEGY_TRACE_HEADER_SIZE] = {
     [SEGY_TR_YEAR_DATA_REC          ] = 2,
 };
 
+/* Lookup table for field data type. All values not explicitly set are 0 */
+static uint8_t tr_field_type[SEGY_TRACE_HEADER_SIZE] = {
+    [SEGY_TR_SEQ_LINE               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SEQ_FILE               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_FIELD_RECORD           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_NUMBER_ORIG_FIELD      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_ENERGY_SOURCE_POINT    ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_ENSEMBLE               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_NUM_IN_ENSEMBLE        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_TRACE_ID               ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SUMMED_TRACES          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_STACKED_TRACES         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DATA_USE               ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_OFFSET                 ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_RECV_GROUP_ELEV        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_SURF_ELEV       ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_DEPTH           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_RECV_DATUM_ELEV        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_DATUM_ELEV      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_WATER_DEPTH     ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_GROUP_WATER_DEPTH      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_ELEV_SCALAR            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_GROUP_SCALAR    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_X               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_Y               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_GROUP_X                ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_GROUP_Y                ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_COORD_UNITS            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_WEATHERING_VELO        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SUBWEATHERING_VELO     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_UPHOLE_TIME     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GROUP_UPHOLE_TIME      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_STATIC_CORR     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GROUP_STATIC_CORR      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TOT_STATIC_APPLIED     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LAG_A                  ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LAG_B                  ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DELAY_REC_TIME         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MUTE_TIME_START        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MUTE_TIME_END          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SAMPLE_COUNT           ] = SEGY_UNSIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SAMPLE_INTER           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GAIN_TYPE              ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_INSTR_GAIN_CONST       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_INSTR_INIT_GAIN        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_CORRELATED             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_FREQ_START       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_FREQ_END         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_LENGTH           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_TYPE             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_TAPERLEN_START   ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_TAPERLEN_END     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TAPER_TYPE             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_ALIAS_FILT_FREQ        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_ALIAS_FILT_SLOPE       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_NOTCH_FILT_FREQ        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_NOTCH_FILT_SLOPE       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LOW_CUT_FREQ           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_HIGH_CUT_FREQ          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LOW_CUT_SLOPE          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_HIGH_CUT_SLOPE         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_YEAR_DATA_REC          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DAY_OF_YEAR            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_HOUR_OF_DAY            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MIN_OF_HOUR            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SEC_OF_MIN             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TIME_BASE_CODE         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_WEIGHTING_FAC          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GEOPHONE_GROUP_ROLL1   ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GEOPHONE_GROUP_FIRST   ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GEOPHONE_GROUP_LAST    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GAP_SIZE               ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_OVER_TRAVEL            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_CDP_X                  ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_CDP_Y                  ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_INLINE                 ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_CROSSLINE              ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SHOT_POINT             ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SHOT_POINT_SCALAR      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MEASURE_UNIT           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TRANSDUCTION_MANT      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_TRANSDUCTION_EXP       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TRANSDUCTION_UNIT      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DEVICE_ID              ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SCALAR_TRACE_HEADER    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_TYPE            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_ENERGY_DIR_VERT ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_ENERGY_DIR_XLINE] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_ENERGY_DIR_ILINE] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_MEASURE_MANT    ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_MEASURE_EXP     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_MEASURE_UNIT    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_UNASSIGNED1            ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_UNASSIGNED2            ] = SEGY_SIGNED_INTEGER_4_BYTE,
+};
+
+
 #define HEADER_SIZE SEGY_TEXT_HEADER_SIZE
+
+
+/* Lookup table for binary header data type. All values not explicitly set are 0 */
+static uint8_t b_field_type[SEGY_BINARY_HEADER_SIZE] = {
+    [- HEADER_SIZE + SEGY_BIN_JOB_ID                ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_LINE_NUMBER           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_REEL_NUMBER           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_TRACES                ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_AUX_TRACES            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_INTERVAL              ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_INTERVAL_ORIG         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SAMPLES               ] = SEGY_UNSIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SAMPLES_ORIG          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_FORMAT                ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_ENSEMBLE_FOLD         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SORTING_CODE          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_VERTICAL_SUM          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_START      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_END        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_LENGTH          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP                 ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_CHANNEL         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_START     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_END       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_TAPER                 ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_CORRELATED_TRACES     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_BIN_GAIN_RECOVERY     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_AMPLITUDE_RECOVERY    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_MEASUREMENT_SYSTEM    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_IMPULSE_POLARITY      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_VIBRATORY_POLARITY    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_TRACES            ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_AUX_TRACES        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES_ORIG      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_ENSEMBLE_FOLD     ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED1           ] = SEGY_NOT_IN_USE_1,
+    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION         ] = SEGY_UNSIGNED_CHAR_1_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION_MINOR   ] = SEGY_UNSIGNED_CHAR_1_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_TRACE_FLAG            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_HEADERS           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED2           ] = SEGY_NOT_IN_USE_1,
+};
+
 
 /*
  * Supporting same byte offsets as in the segy specification, i.e. from the
@@ -597,32 +738,34 @@ no_mmap:
 }
 
 static int get_field( const char* header,
-                      const int* table,
+                      const uint8_t* table,
                       int field,
-                      int32_t* f ) {
+                      FieldData* fd) {
+    fd->type = table[ field ];
 
-    const int bsize = table[ field ];
-    uint32_t buf32 = 0;
-    uint16_t buf16 = 0;
-    uint8_t  buf8  = 0;
+    fd->buffer = 0;
 
-    switch( bsize ) {
-        case 4:
-            memcpy( &buf32, header + (field - 1), 4 );
-            *f = (int32_t)be32toh( buf32 );
+    switch ( fd->type ) {
+
+    case SEGY_SIGNED_INTEGER_4_BYTE:
+        memcpy( &(fd->buffer), header + (field - 1), formatsize( fd->type ));
+        fd->buffer = (int32_t)be32toh( (int32_t)fd->buffer);
             return SEGY_OK;
 
-        case 2:
-            memcpy( &buf16, header + (field - 1), 2 );
-            *f = (int16_t)be16toh( buf16 );
+    case SEGY_SIGNED_SHORT_2_BYTE:
+        memcpy( &(fd->buffer), header + (field - 1), formatsize( fd->type ));
+        fd->buffer = (int16_t)be16toh( (int16_t)fd->buffer);
             return SEGY_OK;
 
-        case 1:
-            memcpy(&buf8, header + (field - 1), 1);
-            *f = buf8;
+    case SEGY_UNSIGNED_SHORT_2_BYTE:
+        memcpy( &(fd->buffer), header + (field - 1), formatsize( fd->type ));
+        fd->buffer = (uint16_t)be16toh( (uint16_t)fd->buffer);
             return SEGY_OK;
 
-        case 0:
+    case SEGY_UNSIGNED_CHAR_1_BYTE:
+        memcpy( &(fd->buffer), header + (field - 1), formatsize( fd->type ));
+        fd->buffer = (uint8_t) fd->buffer;
+        return SEGY_OK;
         default:
             return SEGY_INVALID_FIELD;
     }
@@ -632,7 +775,11 @@ int segy_get_field( const char* traceheader, int field, int* f ) {
     if( field < 0 || field >= SEGY_TRACE_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    return get_field( traceheader, field_size, field, f );
+    FieldData fd;
+    int err = get_field( traceheader, tr_field_type, field, &fd );
+    if ( err != SEGY_OK ) return err;
+    *f = (int)fd.buffer;
+    return err;
 }
 
 int segy_get_bfield( const char* binheader, int field, int32_t* f ) {
@@ -641,7 +788,11 @@ int segy_get_bfield( const char* binheader, int field, int32_t* f ) {
     if( field < 0 || field >= SEGY_BINARY_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    return get_field( binheader, bfield_size, field, f );
+    FieldData fd;
+    int err = get_field( binheader, b_field_type, field, &fd );
+    if ( err != SEGY_OK ) return err;
+    *f = (int32_t)fd.buffer;
+    return err;
 }
 
 static int set_field( char* header, const int* table, int field, int32_t val ) {
@@ -750,10 +901,6 @@ int segy_field_forall( segy_file* fp,
     err = segy_get_field( header, field, &f );
     if( err != SEGY_OK ) return SEGY_INVALID_ARGS;
 
-    // since segy_get_field didn't fail earlier, it is safe to look up the word
-    // size
-    const int word_size = field_size[field];
-
     int slicelen = slicelength( start, stop, step );
 
     // check *once* that we don't look past the end-of-file
@@ -770,9 +917,12 @@ int segy_field_forall( segy_file* fp,
     if( fp->addr ) {
         for( int i = start; slicelen > 0; i += step, ++buf, --slicelen ) {
             segy_seek( fp, i, trace0, trace_bsize );
-            get_field( fp->cur, field_size, field, &f );
-            if (lsb) f = bswap_header_word(f, word_size);
-            *buf = f;
+
+            FieldData fd;
+            err = get_field( fp->cur, tr_field_type, field, &fd );
+            if( err != 0 ) return SEGY_FSEEK_ERROR;
+            if (lsb) fd.buffer = bswap_header_word(fd.buffer, formatsize( fd.type ));
+            *buf = fd.buffer;
         }
 
         return SEGY_OK;
@@ -795,9 +945,11 @@ int segy_field_forall( segy_file* fp,
         size_t readc = fread( header + zfield, sizeof(uint32_t), 1, fp->fp );
         if( readc != 1 ) return SEGY_FREAD_ERROR;
 
-        get_field( header, field_size, field, &f );
-        if (lsb) f = bswap_header_word(f, word_size);
-        *buf = f;
+        FieldData fd;
+        err = get_field( header, tr_field_type, field, &fd );
+        if( err != 0 ) return SEGY_FSEEK_ERROR;
+        if (lsb) fd.buffer = bswap_header_word((int32_t)fd.buffer, formatsize( fd.type ));
+        *buf = (int)fd.buffer;
     }
 
     return SEGY_OK;

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -686,31 +686,32 @@ int segy_get_bfield( const char* binheader, int field, int32_t* f ) {
 }
 
 static int set_field( char* header,
-    const uint8_t* table,
-    int field,
-    FieldData* fd) {
-    fd->type = table[ field ];
+                      const uint8_t* table,
+                      int field,
+                      const field_data* fd ) {
 
-    switch ( fd->type ) {
+    field_data w_fd = {.buffer = fd->buffer, .type = table[ field ]};
+
+    switch ( w_fd.type ) {
 
         case SEGY_SIGNED_INTEGER_4_BYTE:
-            fd->buffer = htobe32( (int32_t)fd->buffer );
-            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
+            w_fd.buffer = htobe32( (int32_t)w_fd.buffer );
+            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
             return SEGY_OK;
 
         case SEGY_SIGNED_SHORT_2_BYTE:
-            fd->buffer = htobe16( (int16_t)fd->buffer );
-            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
+            w_fd.buffer = htobe16( (int16_t)w_fd.buffer );
+            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
             return SEGY_OK;
 
         case SEGY_UNSIGNED_SHORT_2_BYTE:
-            fd->buffer = htobe16( (uint16_t)fd->buffer );
-            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
+            w_fd.buffer = htobe16( (uint16_t)w_fd.buffer );
+            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
             return SEGY_OK;
 
         case SEGY_UNSIGNED_CHAR_1_BYTE:
-            fd->buffer = (uint8_t) fd->buffer;
-            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
+            w_fd.buffer = (uint8_t) w_fd.buffer;
+            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
             return SEGY_OK;
 
         default:
@@ -722,7 +723,7 @@ int segy_set_field( char* traceheader, int field, int val ) {
     if( field < 0 || field >= SEGY_TRACE_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    FieldData fd = {.buffer = val};
+    field_data fd = {.buffer = val};
     return set_field( traceheader, tr_field_type, field, &fd );
 }
 
@@ -732,8 +733,8 @@ int segy_set_bfield( char* binheader, int field, int val ) {
     if( field < 0 || field >= SEGY_BINARY_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    FieldData fd = {.buffer = val};
-    return set_field( binheader, b_field_type, field, &fd );
+    field_data fd = {.buffer = val};
+    return set_field( binheader, bin_field_type, field, &fd );
 }
 
 static int slicelength( int start, int stop, int step ) {

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -689,27 +689,28 @@ static int set_field( char* header,
                       const field_data* fd ) {
 
     field_data w_fd = {.buffer = fd->buffer, .type = table[ field ]};
+    uint8_t * buf8 = (uint8_t*)&w_fd.buffer;
+    uint16_t* buf16 = (uint16_t*)&w_fd.buffer;
+    uint32_t* buf32 = (uint32_t*)&w_fd.buffer;
 
     switch ( w_fd.type ) {
 
         case SEGY_SIGNED_INTEGER_4_BYTE:
-            w_fd.buffer = htobe32( (int32_t)w_fd.buffer );
-            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
+        case SEGY_UNSIGNED_INTEGER_4_BYTE:
+            *buf32 = htobe32( *buf32 );
+            memcpy( header + (field - 1), buf32, formatsize( w_fd.type ));
             return SEGY_OK;
 
         case SEGY_SIGNED_SHORT_2_BYTE:
-            w_fd.buffer = htobe16( (int16_t)w_fd.buffer );
-            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
-            return SEGY_OK;
-
         case SEGY_UNSIGNED_SHORT_2_BYTE:
-            w_fd.buffer = htobe16( (uint16_t)w_fd.buffer );
-            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
+            *buf16 = htobe16( *buf16 );
+            memcpy( header + (field - 1), buf16, formatsize( w_fd.type ));
             return SEGY_OK;
 
         case SEGY_UNSIGNED_CHAR_1_BYTE:
-            w_fd.buffer = (uint8_t) w_fd.buffer;
-            memcpy( header + (field - 1), &(w_fd.buffer), formatsize( w_fd.type ));
+        case SEGY_SIGNED_CHAR_1_BYTE:
+            *buf8 = (uint8_t) *buf8;
+            memcpy( header + (field - 1), buf8, formatsize( w_fd.type ));
             return SEGY_OK;
 
         default:

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -222,103 +222,6 @@ void ieee2ibm( void* to, const void* from ) {
     memcpy( to, &u, sizeof( u ) );
 }
 
-/* Lookup table for field sizes. All values not explicitly set are 0 */
-static int field_size[SEGY_TRACE_HEADER_SIZE] = {
-    [SEGY_TR_CDP_X                  ] = 4,
-    [SEGY_TR_CDP_Y                  ] = 4,
-    [SEGY_TR_CROSSLINE              ] = 4,
-    [SEGY_TR_ENERGY_SOURCE_POINT    ] = 4,
-    [SEGY_TR_ENSEMBLE               ] = 4,
-    [SEGY_TR_FIELD_RECORD           ] = 4,
-    [SEGY_TR_GROUP_WATER_DEPTH      ] = 4,
-    [SEGY_TR_GROUP_X                ] = 4,
-    [SEGY_TR_GROUP_Y                ] = 4,
-    [SEGY_TR_INLINE                 ] = 4,
-    [SEGY_TR_NUMBER_ORIG_FIELD      ] = 4,
-    [SEGY_TR_NUM_IN_ENSEMBLE        ] = 4,
-    [SEGY_TR_OFFSET                 ] = 4,
-    [SEGY_TR_RECV_DATUM_ELEV        ] = 4,
-    [SEGY_TR_RECV_GROUP_ELEV        ] = 4,
-    [SEGY_TR_SEQ_FILE               ] = 4,
-    [SEGY_TR_SEQ_LINE               ] = 4,
-    [SEGY_TR_SHOT_POINT             ] = 4,
-    [SEGY_TR_SOURCE_DATUM_ELEV      ] = 4,
-    [SEGY_TR_SOURCE_DEPTH           ] = 4,
-    [SEGY_TR_SOURCE_MEASURE_MANT    ] = 4,
-    [SEGY_TR_SOURCE_SURF_ELEV       ] = 4,
-    [SEGY_TR_SOURCE_WATER_DEPTH     ] = 4,
-    [SEGY_TR_SOURCE_X               ] = 4,
-    [SEGY_TR_SOURCE_Y               ] = 4,
-    [SEGY_TR_TRANSDUCTION_MANT      ] = 4,
-    [SEGY_TR_UNASSIGNED1            ] = 4,
-    [SEGY_TR_UNASSIGNED2            ] = 4,
-
-    [SEGY_TR_ALIAS_FILT_FREQ        ] = 2,
-    [SEGY_TR_ALIAS_FILT_SLOPE       ] = 2,
-    [SEGY_TR_COORD_UNITS            ] = 2,
-    [SEGY_TR_CORRELATED             ] = 2,
-    [SEGY_TR_DATA_USE               ] = 2,
-    [SEGY_TR_DAY_OF_YEAR            ] = 2,
-    [SEGY_TR_DELAY_REC_TIME         ] = 2,
-    [SEGY_TR_DEVICE_ID              ] = 2,
-    [SEGY_TR_ELEV_SCALAR            ] = 2,
-    [SEGY_TR_GAIN_TYPE              ] = 2,
-    [SEGY_TR_GAP_SIZE               ] = 2,
-    [SEGY_TR_GEOPHONE_GROUP_FIRST   ] = 2,
-    [SEGY_TR_GEOPHONE_GROUP_LAST    ] = 2,
-    [SEGY_TR_GEOPHONE_GROUP_ROLL1   ] = 2,
-    [SEGY_TR_GROUP_STATIC_CORR      ] = 2,
-    [SEGY_TR_GROUP_UPHOLE_TIME      ] = 2,
-    [SEGY_TR_HIGH_CUT_FREQ          ] = 2,
-    [SEGY_TR_HIGH_CUT_SLOPE         ] = 2,
-    [SEGY_TR_HOUR_OF_DAY            ] = 2,
-    [SEGY_TR_INSTR_GAIN_CONST       ] = 2,
-    [SEGY_TR_INSTR_INIT_GAIN        ] = 2,
-    [SEGY_TR_LAG_A                  ] = 2,
-    [SEGY_TR_LAG_B                  ] = 2,
-    [SEGY_TR_LOW_CUT_FREQ           ] = 2,
-    [SEGY_TR_LOW_CUT_SLOPE          ] = 2,
-    [SEGY_TR_MEASURE_UNIT           ] = 2,
-    [SEGY_TR_MIN_OF_HOUR            ] = 2,
-    [SEGY_TR_MUTE_TIME_END          ] = 2,
-    [SEGY_TR_MUTE_TIME_START        ] = 2,
-    [SEGY_TR_NOTCH_FILT_FREQ        ] = 2,
-    [SEGY_TR_NOTCH_FILT_SLOPE       ] = 2,
-    [SEGY_TR_OVER_TRAVEL            ] = 2,
-    [SEGY_TR_SAMPLE_COUNT           ] = 2,
-    [SEGY_TR_SAMPLE_INTER           ] = 2,
-    [SEGY_TR_SCALAR_TRACE_HEADER    ] = 2,
-    [SEGY_TR_SEC_OF_MIN             ] = 2,
-    [SEGY_TR_SHOT_POINT_SCALAR      ] = 2,
-    [SEGY_TR_SOURCE_ENERGY_DIR_VERT ] = 2,
-    [SEGY_TR_SOURCE_ENERGY_DIR_XLINE] = 2,
-    [SEGY_TR_SOURCE_ENERGY_DIR_ILINE] = 2,
-    [SEGY_TR_SOURCE_GROUP_SCALAR    ] = 2,
-    [SEGY_TR_SOURCE_MEASURE_EXP     ] = 2,
-    [SEGY_TR_SOURCE_MEASURE_UNIT    ] = 2,
-    [SEGY_TR_SOURCE_STATIC_CORR     ] = 2,
-    [SEGY_TR_SOURCE_TYPE            ] = 2,
-    [SEGY_TR_SOURCE_UPHOLE_TIME     ] = 2,
-    [SEGY_TR_STACKED_TRACES         ] = 2,
-    [SEGY_TR_SUBWEATHERING_VELO     ] = 2,
-    [SEGY_TR_SUMMED_TRACES          ] = 2,
-    [SEGY_TR_SWEEP_FREQ_END         ] = 2,
-    [SEGY_TR_SWEEP_FREQ_START       ] = 2,
-    [SEGY_TR_SWEEP_LENGTH           ] = 2,
-    [SEGY_TR_SWEEP_TAPERLEN_END     ] = 2,
-    [SEGY_TR_SWEEP_TAPERLEN_START   ] = 2,
-    [SEGY_TR_SWEEP_TYPE             ] = 2,
-    [SEGY_TR_TAPER_TYPE             ] = 2,
-    [SEGY_TR_TIME_BASE_CODE         ] = 2,
-    [SEGY_TR_TOT_STATIC_APPLIED     ] = 2,
-    [SEGY_TR_TRACE_ID               ] = 2,
-    [SEGY_TR_TRANSDUCTION_EXP       ] = 2,
-    [SEGY_TR_TRANSDUCTION_UNIT      ] = 2,
-    [SEGY_TR_WEATHERING_VELO        ] = 2,
-    [SEGY_TR_WEIGHTING_FAC          ] = 2,
-    [SEGY_TR_YEAR_DATA_REC          ] = 2,
-};
-
 /*
     Lookup table for field data type. All values not explicitly set are 0.
     Datatype enumeration is defined incrementally with 1 as the base.
@@ -468,54 +371,6 @@ static uint8_t bin_field_type[SEGY_BINARY_HEADER_SIZE] = {
     [- HEADER_SIZE + SEGY_BIN_UNASSIGNED2           ] = SEGY_NOT_IN_USE_1,
 };
 
-
-/*
- * Supporting same byte offsets as in the segy specification, i.e. from the
- * start of the *text header*, not the binary header.
- */
-static int bfield_size[] = {
-    [- HEADER_SIZE + SEGY_BIN_JOB_ID                ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_LINE_NUMBER           ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_REEL_NUMBER           ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_TRACES            ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_AUX_TRACES        ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES           ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES_ORIG      ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_ENSEMBLE_FOLD     ] = 4,
-
-    [- HEADER_SIZE + SEGY_BIN_TRACES                ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_AUX_TRACES            ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_INTERVAL              ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_INTERVAL_ORIG         ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SAMPLES               ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SAMPLES_ORIG          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_FORMAT                ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_ENSEMBLE_FOLD         ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SORTING_CODE          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_VERTICAL_SUM          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_START      ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_END        ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_LENGTH          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP                 ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_CHANNEL         ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_START     ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_END       ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_TAPER                 ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_CORRELATED_TRACES     ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_BIN_GAIN_RECOVERY     ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_AMPLITUDE_RECOVERY    ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_MEASUREMENT_SYSTEM    ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_IMPULSE_POLARITY      ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_VIBRATORY_POLARITY    ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_TRACE_FLAG            ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_EXT_HEADERS           ] = 2,
-
-    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION         ] = 1,
-    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION_MINOR   ] = 1,
-
-    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED1           ] = 0,
-    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED2           ] = 0,
-};
 
 /*
  * Determine the file size in bytes. If this function succeeds, the file
@@ -830,30 +685,34 @@ int segy_get_bfield( const char* binheader, int field, int32_t* f ) {
     return err;
 }
 
-static int set_field( char* header, const int* table, int field, int32_t val ) {
-    const int bsize = table[ field ];
+static int set_field( char* header,
+    const uint8_t* table,
+    int field,
+    FieldData* fd) {
+    fd->type = table[ field ];
 
-    uint32_t buf32;
-    uint16_t buf16;
-    uint8_t  buf8;
+    switch ( fd->type ) {
 
-    switch( bsize ) {
-        case 4:
-            buf32 = htobe32( (uint32_t)val );
-            memcpy( header + (field - 1), &buf32, sizeof( buf32 ) );
+        case SEGY_SIGNED_INTEGER_4_BYTE:
+            fd->buffer = htobe32( (int32_t)fd->buffer );
+            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
             return SEGY_OK;
 
-        case 2:
-            buf16 = htobe16( (uint16_t)val );
-            memcpy( header + (field - 1), &buf16, sizeof( buf16 ) );
+        case SEGY_SIGNED_SHORT_2_BYTE:
+            fd->buffer = htobe16( (int16_t)fd->buffer );
+            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
             return SEGY_OK;
 
-        case 1:
-            buf8 = (uint8_t)val;
-            memcpy(header + (field - 1), &buf8, sizeof(buf8));
+        case SEGY_UNSIGNED_SHORT_2_BYTE:
+            fd->buffer = htobe16( (uint16_t)fd->buffer );
+            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
             return SEGY_OK;
 
-        case 0:
+        case SEGY_UNSIGNED_CHAR_1_BYTE:
+            fd->buffer = (uint8_t) fd->buffer;
+            memcpy( header + (field - 1), &(fd->buffer), formatsize( fd->type ));
+            return SEGY_OK;
+
         default:
             return SEGY_INVALID_FIELD;
     }
@@ -863,7 +722,8 @@ int segy_set_field( char* traceheader, int field, int val ) {
     if( field < 0 || field >= SEGY_TRACE_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    return set_field( traceheader, field_size, field, val );
+    FieldData fd = {.buffer = val};
+    return set_field( traceheader, tr_field_type, field, &fd );
 }
 
 int segy_set_bfield( char* binheader, int field, int val ) {
@@ -872,7 +732,8 @@ int segy_set_bfield( char* binheader, int field, int val ) {
     if( field < 0 || field >= SEGY_BINARY_HEADER_SIZE )
         return SEGY_INVALID_FIELD;
 
-    return set_field( binheader, bfield_size, field, val );
+    FieldData fd = {.buffer = val};
+    return set_field( binheader, b_field_type, field, &fd );
 }
 
 static int slicelength( int start, int stop, int step ) {
@@ -1565,7 +1426,7 @@ int segy_sorting( segy_file* fp,
             return SEGY_INVALID_FIELD;
         if( f >= SEGY_TRACE_HEADER_SIZE )
             return SEGY_INVALID_FIELD;
-        if( field_size[ f ] == 0 )
+        if( tr_field_type[ f ] == 0 )
             return SEGY_INVALID_FIELD;
     }
 
@@ -1668,7 +1529,7 @@ int segy_offsets( segy_file* fp,
      * check that field value is sane, so that we don't have to check
      * segy_get_field's error
      */
-    if( field_size[ il ] == 0 || field_size[ xl ] == 0 )
+    if( tr_field_type[ il ] == 0 || tr_field_type[ xl ] == 0 )
         return SEGY_INVALID_FIELD;
 
     err = segy_traceheader( fp, 0, header, trace0, trace_bsize );
@@ -1702,7 +1563,7 @@ int segy_offset_indices( segy_file* fp,
     int32_t x = 0;
     char header[ SEGY_TRACE_HEADER_SIZE ];
 
-    if( field_size[ offset_field ] == 0 )
+    if( tr_field_type[ offset_field ] == 0 )
         return SEGY_INVALID_FIELD;
 
     for( int i = 0; i < offsets; ++i ) {

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -816,8 +816,10 @@ int segy_field_forall( segy_file* fp,
             field_data fd;
             err = get_field( fp->cur, tr_field_type, field, &fd );
             if( err != 0 ) return err;
-            if (lsb) fd.buffer = bswap_header_word(fd.buffer, formatsize( fd.type ));
-            *buf = (int)fd.buffer;
+            err = fd_get_int( &fd, &f );
+            if( err != 0 ) return err;
+            if (lsb) f = bswap_header_word(f, formatsize( fd.type ));
+            *buf = f;
         }
 
         return SEGY_OK;
@@ -843,8 +845,10 @@ int segy_field_forall( segy_file* fp,
         field_data fd;
         err = get_field( header, tr_field_type, field, &fd );
         if( err != 0 ) return err;
-        if (lsb) fd.buffer = bswap_header_word((int32_t)fd.buffer, formatsize( fd.type ));
-        *buf = (int)fd.buffer;
+        err = fd_get_int( &fd, &f );
+        if( err != 0 ) return err;
+        if (lsb) f = bswap_header_word(f, formatsize( fd.type ));
+        *buf = f;
     }
 
     return SEGY_OK;

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -821,6 +821,7 @@ static int memread( void* dest, const segy_file* fp, const void* src, size_t n )
     return SEGY_OK;
 }
 
+// cppcheck-suppress constParameterPointer
 static int memwrite( segy_file* fp, void* dest, const void* src, size_t n ) {
     const void* begin = fp->addr;
     const void* end = (const char*)fp->addr + fp->fsize;
@@ -1897,6 +1898,7 @@ int segy_readsubtr( segy_file* fp,
      */
     void* tracebuf = rangebuf ? rangebuf : malloc( elems * elemsize );
 
+    // cppcheck-suppress nullPointerOutOfMemory
     const int readc = (int) fread( tracebuf, elemsize, elems, fp->fp );
     if( readc != elems ) {
         if( !rangebuf ) free( tracebuf );
@@ -2013,6 +2015,7 @@ int segy_writesubtr( segy_file* fp,
      */
     if( !fp->addr && (step == 1 || step == -1) && fp->lsb ) {
         void* tracebuf = rangebuf ? rangebuf : malloc( elems * elemsize );
+        // cppcheck-suppress nullPointerOutOfMemory
         memcpy( tracebuf, buf, elemsize * elems );
 
         if (step == -1) reverse(tracebuf, elems, elemsize);
@@ -2061,6 +2064,7 @@ int segy_writesubtr( segy_file* fp,
     void* tracebuf = rangebuf ? rangebuf : malloc( elems * elemsize );
 
     // like in readsubtr, read a larger chunk and then step through that
+    // cppcheck-suppress nullPointerOutOfMemory
     const int readc = (int) fread( tracebuf, elemsize, elems, fp->fp );
     if( readc != elems ) { free( tracebuf ); return SEGY_FREAD_ERROR; }
     /* rewind, because fread advances the file pointer */

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -223,9 +223,8 @@ void ieee2ibm( void* to, const void* from ) {
 }
 
 /*
-    Lookup table for field data type. All values not explicitly set are 0.
-    Datatype enumeration is defined incrementally with 1 as the base.
-    Thus, fields with undefined type will be assigned datatype 0.
+    Lookup table for segy field data types. Types are defined in the SEGY_FORMAT enum.
+    All values not explicitly set are 0 which is undefined in the SEGY_FORMAT.
 */
 static uint8_t tr_field_type[SEGY_TRACE_HEADER_SIZE] = {
     [SEGY_TR_SEQ_LINE               ] = SEGY_SIGNED_INTEGER_4_BYTE,
@@ -326,9 +325,8 @@ static uint8_t tr_field_type[SEGY_TRACE_HEADER_SIZE] = {
 #define HEADER_SIZE SEGY_TEXT_HEADER_SIZE
 
 /*
-    Lookup table for binary header data type. All values not explicitly set are 0.
-    Datatype enumeration is defined incrementally with 1 as the base.
-    Thus, fields with undefined type will be assigned datatype 0.
+    Lookup table for segy binary field data types. Types are defined in the SEGY_FORMAT enum.
+    All values not explicitly set are 0 which is undefined in the SEGY_FORMAT.
 */
 static uint8_t bin_field_type[SEGY_BINARY_HEADER_SIZE] = {
     [- HEADER_SIZE + SEGY_BIN_JOB_ID                ] = SEGY_SIGNED_INTEGER_4_BYTE,

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -2060,3 +2060,38 @@ TEST_CASE("segy_samples uses ext-samples word", "[c.segy]") {
         CHECK(samples == 1);
     }
 }
+
+TEST_CASE(
+    "segy_get_field reads values correctly",
+    "[c.segy]" ) {
+
+    char header[ SEGY_TRACE_HEADER_SIZE ] = { 0 };
+
+    SECTION("test negative odd near-min int16") {
+        int16_t write_v = -32767;
+        const uint8_t *p = (uint8_t*)&write_v;
+
+        header[SEGY_TR_TRACE_ID-1] = (unsigned char)p[1];
+        header[SEGY_TR_TRACE_ID-0] = (unsigned char)p[0];
+
+        int32_t read_v;
+        Err err = segy_get_field( header, SEGY_TR_TRACE_ID, &read_v );
+        CHECK( success( err ) );
+        CHECK( read_v == write_v );
+    }
+
+    SECTION("test negative even near-min int16") {
+        int16_t write_v = -32766;
+        const uint8_t *p = (uint8_t*)&write_v;
+
+        header[SEGY_TR_TRACE_ID-1] = (unsigned char)p[1];
+        header[SEGY_TR_TRACE_ID-0] = (unsigned char)p[0];
+
+        int32_t read_v;
+        Err err = segy_get_field( header, SEGY_TR_TRACE_ID, &read_v );
+        CHECK( success( err ) );
+        CHECK( read_v == write_v );
+    }
+
+    // keep on
+}

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -1762,6 +1762,7 @@ SCENARIO( "reading a 2-byte int file", "[c.segy][2-byte]" ) {
             CHECK( trace_bsize == 75 * 2 );
         }
 
+        // cppcheck-suppress unknownMacro
         WHEN( "the format is valid" ) THEN( "setting format succeeds" ) {
                 Err err = segy_set_format( fp, format );
                 CHECK( err == Err::ok() );

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,7 +7,7 @@ if (SKBUILD)
     return ()
 endif ()
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(segyio-python)
 
 if (REQUIRE_PYTHON)


### PR DESCRIPTION
SEG technical standard defines fields for the binary header and the trace header. Each field has a well defined size and in most cases the datatype is also defined. This PR changes the system to solely relay on field size and instead use the filed datatype. This feature will become critical when implementing the new float field that are defined in version 2.0 and 2.1.