### PR TITLE
Fix benchmark CI

### DIFF
--- a/.github/actions/benchmark/action.yaml
+++ b/.github/actions/benchmark/action.yaml
@@ -18,31 +18,35 @@ runs:
     - name: Checkout commit which performance should be measured
       shell: bash
       run: |
+        git restore .
         git fetch origin ${{ inputs.ref }} --depth 1
         git checkout ${{ inputs.ref }}
 
-    - name: Configure
+    - name: Build wheel
+      shell: bash
+      env:
+        CIBW_BUILD_VERBOSITY: 1
+      run: |
+        python -m cibuildwheel --only cp312-manylinux_x86_64 --output-dir ./wheelhouse python/
+
+    - name: Install local wheel
       shell: bash
       run: |
-        cmake -S . -B build \
-          -DBUILD_PYTHON=ON \
-          -DBUILD_SHARED_LIBS=ON \
-          -DCMAKE_BUILD_TYPE=Release \
-
-    - name: Build
-      shell: bash
-      run: |
-        cmake \
-          --build build \
-          --config Release \
-
-    - name: Set PYTHONPATH
-      shell: bash
-      run: echo "PYTHONPATH=$(pwd)/python" >> $GITHUB_ENV
+        pip install ./wheelhouse/*.whl
+        rm -f ./wheelhouse/*.whl
 
     - name: Checkout current commit which contains all tests to run
       shell: bash
       run: git checkout ${{ github.sha }}
+
+    # assure that local segyio doesn't take priority (one installed to pip is used)
+    - name: Remove local segyio
+      shell: bash
+      working-directory: python
+      run: |
+        python -c "import segyio; import inspect; print('before: segyio loaded from ' + inspect.getfile(segyio))"
+        rm -rf $(pwd)/segyio
+        python -c "import segyio; import inspect; print('after: segyio loaded from ' + inspect.getfile(segyio))"
 
     - name: Make segy file
       shell: bash
@@ -79,4 +83,6 @@ runs:
 
     - name: Remove build artifacts
       shell: bash
-      run: git clean -df --exclude=.benchmarks
+      run: |
+        git clean -df --exclude=.benchmarks
+        pip uninstall -y segyio

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install cibuildwheel
+        run: python3 -m pip install cibuildwheel
+
       - name: Install build/test dependencies
-        shell: bash
         working-directory: python
         run: |
           python3 -m pip install -r requirements-dev.txt


### PR DESCRIPTION
Current logic is flawed.
Intention of benchmark tests was to build library from two different commits. However only C/C++ part was built separately, python code was not touched.

When current commit's directory was checked out to run the fresh tests, so was other python code: tests were always run on the same python part of the library.

To fix that, build a local wheel from existing code and make sure it is being used instead of local code.