### PR TITLE
Reading and writing fields using field datatype 

### DIFF
--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -450,6 +450,27 @@ int segy_crossline_stride( int sorting,
                            int crossline_count,
                            int* stride );
 
+
+typedef enum {
+    SEGY_IBM_FLOAT_4_BYTE = 1,
+    SEGY_SIGNED_INTEGER_4_BYTE = 2,
+    SEGY_SIGNED_SHORT_2_BYTE = 3,
+    SEGY_FIXED_POINT_WITH_GAIN_4_BYTE = 4, // Obsolete
+    SEGY_IEEE_FLOAT_4_BYTE = 5,
+    SEGY_IEEE_FLOAT_8_BYTE = 6,
+    SEGY_SIGNED_CHAR_3_BYTE = 7,
+    SEGY_SIGNED_INTEGER_3_BYTE = 7,
+    SEGY_SIGNED_CHAR_1_BYTE = 8,
+    SEGY_SIGNED_INTEGER_8_BYTE = 9,
+    SEGY_UNSIGNED_INTEGER_4_BYTE = 10,
+    SEGY_UNSIGNED_SHORT_2_BYTE = 11,
+    SEGY_UNSIGNED_INTEGER_8_BYTE = 12,
+    SEGY_UNSIGNED_INTEGER_3_BYTE = 15,
+    SEGY_UNSIGNED_CHAR_1_BYTE = 16,
+    SEGY_NOT_IN_USE_1 = 19,
+    SEGY_NOT_IN_USE_2 = 20,
+} SEGY_FORMAT;
+
 typedef enum {
     SEGY_TR_SEQ_LINE                = 1,
     SEGY_TR_SEQ_FILE                = 5,
@@ -586,25 +607,6 @@ typedef enum {
     SEGY_BIN_UNASSIGNED2            = 3507,
 } SEGY_BINFIELD;
 
-typedef enum {
-    SEGY_IBM_FLOAT_4_BYTE = 1,
-    SEGY_SIGNED_INTEGER_4_BYTE = 2,
-    SEGY_SIGNED_SHORT_2_BYTE = 3,
-    SEGY_FIXED_POINT_WITH_GAIN_4_BYTE = 4, // Obsolete
-    SEGY_IEEE_FLOAT_4_BYTE = 5,
-    SEGY_IEEE_FLOAT_8_BYTE = 6,
-    SEGY_SIGNED_CHAR_3_BYTE = 7,
-    SEGY_SIGNED_INTEGER_3_BYTE = 7,
-    SEGY_SIGNED_CHAR_1_BYTE = 8,
-    SEGY_SIGNED_INTEGER_8_BYTE = 9,
-    SEGY_UNSIGNED_INTEGER_4_BYTE = 10,
-    SEGY_UNSIGNED_SHORT_2_BYTE = 11,
-    SEGY_UNSIGNED_INTEGER_8_BYTE = 12,
-    SEGY_UNSIGNED_INTEGER_3_BYTE = 15,
-    SEGY_UNSIGNED_CHAR_1_BYTE = 16,
-    SEGY_NOT_IN_USE_1 = 19,
-    SEGY_NOT_IN_USE_2 = 20,
-} SEGY_FORMAT;
 
 typedef enum {
     SEGY_MSB = 0,

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -34,15 +34,17 @@ extern "C" {
 struct segy_file_handle;
 typedef struct segy_file_handle segy_file;
 
+typedef union {
+    uint8_t u8;
+    uint16_t u16;
+    uint32_t u32;
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+} segy_field_value;
+
 typedef struct {
-    union {
-        uint8_t u8;
-        uint16_t u16;
-        uint32_t u32;
-        int8_t i8;
-        int16_t i16;
-        int32_t i32;
-    } value;
+    segy_field_value value;
     uint8_t datatype;
     int32_t field_index;
     int32_t field_offset;

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -34,6 +34,20 @@ extern "C" {
 struct segy_file_handle;
 typedef struct segy_file_handle segy_file;
 
+typedef struct {
+    union {
+        uint8_t u8;
+        uint16_t u16;
+        uint32_t u32;
+        int8_t i8;
+        int16_t i16;
+        int32_t i32;
+    } value;
+    uint8_t datatype;
+    int32_t field_index;
+    int32_t field_offset;
+} segy_field_data;
+
 segy_file* segy_open( const char* path, const char* mode );
 int segy_mmap( segy_file* );
 int segy_flush( segy_file* );
@@ -452,6 +466,7 @@ int segy_crossline_stride( int sorting,
 
 
 typedef enum {
+    SEGY_UNDEFINED_FIELD = 0,
     SEGY_IBM_FLOAT_4_BYTE = 1,
     SEGY_SIGNED_INTEGER_4_BYTE = 2,
     SEGY_SIGNED_SHORT_2_BYTE = 3,
@@ -626,6 +641,7 @@ typedef enum {
     SEGY_FREAD_ERROR,
     SEGY_FWRITE_ERROR,
     SEGY_INVALID_FIELD,
+    SEGY_INVALID_FIELD_VALUE,
     SEGY_INVALID_SORTING,
     SEGY_MISSING_LINE_INDEX,
     SEGY_INVALID_OFFSETS,

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -205,102 +205,6 @@ static void bswap16_mem( char* dst, const char* src ) {
     memcpy( dst, &v, 2 );
 }
 
-/* Lookup table for field sizes. All values not explicitly set are 0 */
-static int field_size[SEGY_TRACE_HEADER_SIZE] = {
-    [SEGY_TR_CDP_X                  ] = 4,
-    [SEGY_TR_CDP_Y                  ] = 4,
-    [SEGY_TR_CROSSLINE              ] = 4,
-    [SEGY_TR_ENERGY_SOURCE_POINT    ] = 4,
-    [SEGY_TR_ENSEMBLE               ] = 4,
-    [SEGY_TR_FIELD_RECORD           ] = 4,
-    [SEGY_TR_GROUP_WATER_DEPTH      ] = 4,
-    [SEGY_TR_GROUP_X                ] = 4,
-    [SEGY_TR_GROUP_Y                ] = 4,
-    [SEGY_TR_INLINE                 ] = 4,
-    [SEGY_TR_NUMBER_ORIG_FIELD      ] = 4,
-    [SEGY_TR_NUM_IN_ENSEMBLE        ] = 4,
-    [SEGY_TR_OFFSET                 ] = 4,
-    [SEGY_TR_RECV_DATUM_ELEV        ] = 4,
-    [SEGY_TR_RECV_GROUP_ELEV        ] = 4,
-    [SEGY_TR_SEQ_FILE               ] = 4,
-    [SEGY_TR_SEQ_LINE               ] = 4,
-    [SEGY_TR_SHOT_POINT             ] = 4,
-    [SEGY_TR_SOURCE_DATUM_ELEV      ] = 4,
-    [SEGY_TR_SOURCE_DEPTH           ] = 4,
-    [SEGY_TR_SOURCE_MEASURE_MANT    ] = 4,
-    [SEGY_TR_SOURCE_SURF_ELEV       ] = 4,
-    [SEGY_TR_SOURCE_WATER_DEPTH     ] = 4,
-    [SEGY_TR_SOURCE_X               ] = 4,
-    [SEGY_TR_SOURCE_Y               ] = 4,
-    [SEGY_TR_TRANSDUCTION_MANT      ] = 4,
-    [SEGY_TR_UNASSIGNED1            ] = 4,
-    [SEGY_TR_UNASSIGNED2            ] = 4,
-
-    [SEGY_TR_ALIAS_FILT_FREQ        ] = 2,
-    [SEGY_TR_ALIAS_FILT_SLOPE       ] = 2,
-    [SEGY_TR_COORD_UNITS            ] = 2,
-    [SEGY_TR_CORRELATED             ] = 2,
-    [SEGY_TR_DATA_USE               ] = 2,
-    [SEGY_TR_DAY_OF_YEAR            ] = 2,
-    [SEGY_TR_DELAY_REC_TIME         ] = 2,
-    [SEGY_TR_DEVICE_ID              ] = 2,
-    [SEGY_TR_ELEV_SCALAR            ] = 2,
-    [SEGY_TR_GAIN_TYPE              ] = 2,
-    [SEGY_TR_GAP_SIZE               ] = 2,
-    [SEGY_TR_GEOPHONE_GROUP_FIRST   ] = 2,
-    [SEGY_TR_GEOPHONE_GROUP_LAST    ] = 2,
-    [SEGY_TR_GEOPHONE_GROUP_ROLL1   ] = 2,
-    [SEGY_TR_GROUP_STATIC_CORR      ] = 2,
-    [SEGY_TR_GROUP_UPHOLE_TIME      ] = 2,
-    [SEGY_TR_HIGH_CUT_FREQ          ] = 2,
-    [SEGY_TR_HIGH_CUT_SLOPE         ] = 2,
-    [SEGY_TR_HOUR_OF_DAY            ] = 2,
-    [SEGY_TR_INSTR_GAIN_CONST       ] = 2,
-    [SEGY_TR_INSTR_INIT_GAIN        ] = 2,
-    [SEGY_TR_LAG_A                  ] = 2,
-    [SEGY_TR_LAG_B                  ] = 2,
-    [SEGY_TR_LOW_CUT_FREQ           ] = 2,
-    [SEGY_TR_LOW_CUT_SLOPE          ] = 2,
-    [SEGY_TR_MEASURE_UNIT           ] = 2,
-    [SEGY_TR_MIN_OF_HOUR            ] = 2,
-    [SEGY_TR_MUTE_TIME_END          ] = 2,
-    [SEGY_TR_MUTE_TIME_START        ] = 2,
-    [SEGY_TR_NOTCH_FILT_FREQ        ] = 2,
-    [SEGY_TR_NOTCH_FILT_SLOPE       ] = 2,
-    [SEGY_TR_OVER_TRAVEL            ] = 2,
-    [SEGY_TR_SAMPLE_COUNT           ] = 2,
-    [SEGY_TR_SAMPLE_INTER           ] = 2,
-    [SEGY_TR_SCALAR_TRACE_HEADER    ] = 2,
-    [SEGY_TR_SEC_OF_MIN             ] = 2,
-    [SEGY_TR_SHOT_POINT_SCALAR      ] = 2,
-    [SEGY_TR_SOURCE_ENERGY_DIR_VERT ] = 2,
-    [SEGY_TR_SOURCE_ENERGY_DIR_XLINE] = 2,
-    [SEGY_TR_SOURCE_ENERGY_DIR_ILINE] = 2,
-    [SEGY_TR_SOURCE_GROUP_SCALAR    ] = 2,
-    [SEGY_TR_SOURCE_MEASURE_EXP     ] = 2,
-    [SEGY_TR_SOURCE_MEASURE_UNIT    ] = 2,
-    [SEGY_TR_SOURCE_STATIC_CORR     ] = 2,
-    [SEGY_TR_SOURCE_TYPE            ] = 2,
-    [SEGY_TR_SOURCE_UPHOLE_TIME     ] = 2,
-    [SEGY_TR_STACKED_TRACES         ] = 2,
-    [SEGY_TR_SUBWEATHERING_VELO     ] = 2,
-    [SEGY_TR_SUMMED_TRACES          ] = 2,
-    [SEGY_TR_SWEEP_FREQ_END         ] = 2,
-    [SEGY_TR_SWEEP_FREQ_START       ] = 2,
-    [SEGY_TR_SWEEP_LENGTH           ] = 2,
-    [SEGY_TR_SWEEP_TAPERLEN_END     ] = 2,
-    [SEGY_TR_SWEEP_TAPERLEN_START   ] = 2,
-    [SEGY_TR_SWEEP_TYPE             ] = 2,
-    [SEGY_TR_TAPER_TYPE             ] = 2,
-    [SEGY_TR_TIME_BASE_CODE         ] = 2,
-    [SEGY_TR_TOT_STATIC_APPLIED     ] = 2,
-    [SEGY_TR_TRACE_ID               ] = 2,
-    [SEGY_TR_TRANSDUCTION_EXP       ] = 2,
-    [SEGY_TR_TRANSDUCTION_UNIT      ] = 2,
-    [SEGY_TR_WEATHERING_VELO        ] = 2,
-    [SEGY_TR_WEIGHTING_FAC          ] = 2,
-    [SEGY_TR_YEAR_DATA_REC          ] = 2,
-};
 
 /*
     Lookup table for segy field data types. Types are defined in the SEGY_FORMAT enum.
@@ -449,54 +353,6 @@ static uint8_t bin_field_type[SEGY_BINARY_HEADER_SIZE] = {
     [- HEADER_SIZE + SEGY_BIN_UNASSIGNED2           ] = SEGY_NOT_IN_USE_1,
 };
 
-
-/*
- * Supporting same byte offsets as in the segy specification, i.e. from the
- * start of the *text header*, not the binary header.
- */
-static int bfield_size[] = {
-    [- HEADER_SIZE + SEGY_BIN_JOB_ID                ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_LINE_NUMBER           ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_REEL_NUMBER           ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_TRACES            ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_AUX_TRACES        ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES           ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES_ORIG      ] = 4,
-    [- HEADER_SIZE + SEGY_BIN_EXT_ENSEMBLE_FOLD     ] = 4,
-
-    [- HEADER_SIZE + SEGY_BIN_TRACES                ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_AUX_TRACES            ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_INTERVAL              ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_INTERVAL_ORIG         ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SAMPLES               ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SAMPLES_ORIG          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_FORMAT                ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_ENSEMBLE_FOLD         ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SORTING_CODE          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_VERTICAL_SUM          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_START      ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_END        ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_LENGTH          ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP                 ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_CHANNEL         ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_START     ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_END       ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_TAPER                 ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_CORRELATED_TRACES     ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_BIN_GAIN_RECOVERY     ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_AMPLITUDE_RECOVERY    ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_MEASUREMENT_SYSTEM    ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_IMPULSE_POLARITY      ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_VIBRATORY_POLARITY    ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_TRACE_FLAG            ] = 2,
-    [- HEADER_SIZE + SEGY_BIN_EXT_HEADERS           ] = 2,
-
-    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION         ] = 1,
-    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION_MINOR   ] = 1,
-
-    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED1           ] = 0,
-    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED2           ] = 0,
-};
 
 /*
  * Determine the file size in bytes. If this function succeeds, the file
@@ -876,49 +732,102 @@ int segy_get_bfield( const char* binheader, int field, int32_t* val ) {
     return fd_get_int( &fd, val );
 }
 
-static int set_field( char* header, const int* table, int field, int32_t val ) {
-    const int bsize = table[ field ];
+static int set_field( char* header,
+                      const segy_field_data* fd ) {
 
-    uint32_t buf32;
-    uint16_t buf16;
-    uint8_t  buf8;
+    segy_field_data w_fd = *fd;
 
-    switch( bsize ) {
-        case 4:
-            buf32 = htobe32( (uint32_t)val );
-            memcpy( header + (field - 1), &buf32, sizeof( buf32 ) );
+    switch ( w_fd.datatype ) {
+
+        case SEGY_SIGNED_INTEGER_4_BYTE:
+            w_fd.value.i32 = htobe32( w_fd.value.i32 );
+            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.i32), formatsize( w_fd.datatype ));
             return SEGY_OK;
 
-        case 2:
-            buf16 = htobe16( (uint16_t)val );
-            memcpy( header + (field - 1), &buf16, sizeof( buf16 ) );
+        case SEGY_SIGNED_SHORT_2_BYTE:
+            w_fd.value.i16 = htobe16( w_fd.value.i16 );
+            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.i16), formatsize( w_fd.datatype ));
             return SEGY_OK;
 
-        case 1:
-            buf8 = (uint8_t)val;
-            memcpy(header + (field - 1), &buf8, sizeof(buf8));
+        case SEGY_SIGNED_CHAR_1_BYTE:
+            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.i8), formatsize( w_fd.datatype ));
             return SEGY_OK;
 
-        case 0:
+        case SEGY_UNSIGNED_INTEGER_4_BYTE:
+            w_fd.value.u32 = htobe32( w_fd.value.u32 );
+            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.u32), formatsize( w_fd.datatype ));
+            return SEGY_OK;
+
+        case SEGY_UNSIGNED_SHORT_2_BYTE:
+            w_fd.value.u16 = htobe16( w_fd.value.u16 );
+            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.u16), formatsize( w_fd.datatype ));
+            return SEGY_OK;
+
+        case SEGY_UNSIGNED_CHAR_1_BYTE:
+            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.u8), formatsize( w_fd.datatype ));
+            return SEGY_OK;
+
+        default:
+            return SEGY_INVALID_FIELD;
+    }
+}
+
+
+static int fd_set_int( segy_field_data* fd, int val ) {
+    switch( fd->datatype ) {
+        case SEGY_SIGNED_INTEGER_4_BYTE:
+            fd->value.i32 = val;
+            return SEGY_OK;
+
+        case SEGY_SIGNED_SHORT_2_BYTE:
+            if ( val > INT16_MAX || val < INT16_MIN )
+                return SEGY_INVALID_FIELD_VALUE;
+            fd->value.i16 = (int16_t)val;
+            return SEGY_OK;
+
+        case SEGY_SIGNED_CHAR_1_BYTE:
+            if ( val > INT8_MAX || val < INT8_MIN )
+                return SEGY_INVALID_FIELD_VALUE;
+            fd->value.i8 = (int8_t)val;
+            return SEGY_OK;
+
+        case SEGY_UNSIGNED_SHORT_2_BYTE:
+            if ( val > UINT16_MAX || val < 0 )
+                return SEGY_INVALID_FIELD_VALUE;
+            fd->value.u16 = (uint16_t)val;
+            return SEGY_OK;
+
+        case SEGY_UNSIGNED_CHAR_1_BYTE:
+            if ( val > UINT8_MAX || val < 0 )
+                return SEGY_INVALID_FIELD_VALUE;
+            fd->value.u8 = (uint8_t)val;
+            return SEGY_OK;
+
         default:
             return SEGY_INVALID_FIELD;
     }
 }
 
 int segy_set_field( char* traceheader, int field, int val ) {
-    if( field < 0 || field >= SEGY_TRACE_HEADER_SIZE )
-        return SEGY_INVALID_FIELD;
+    segy_field_data fd;
+    int err = init_segy_field_data( field, &fd );
+    if ( err != SEGY_OK ) return err;
 
-    return set_field( traceheader, field_size, field, val );
+    err = fd_set_int( &fd, val );
+    if ( err != SEGY_OK ) return err;
+    return set_field( traceheader, &fd );
 }
 
 int segy_set_bfield( char* binheader, int field, int val ) {
-    field -= SEGY_TEXT_HEADER_SIZE;
 
-    if( field < 0 || field >= SEGY_BINARY_HEADER_SIZE )
-        return SEGY_INVALID_FIELD;
+    segy_field_data fd;
+    int err = init_segy_field_data( field, &fd );
+    if ( err != SEGY_OK ) return err;
 
-    return set_field( binheader, bfield_size, field, val );
+    err = fd_set_int( &fd, val );
+    if ( err != SEGY_OK ) return err;
+    err = set_field( binheader, &fd );
+    return err;
 }
 
 static int slicelength( int start, int stop, int step ) {
@@ -1559,7 +1468,7 @@ int segy_sorting( segy_file* fp,
             return SEGY_INVALID_FIELD;
         if( f >= SEGY_TRACE_HEADER_SIZE )
             return SEGY_INVALID_FIELD;
-        if( field_size[ f ] == 0 )
+        if( tr_field_type[ f ] == 0 )
             return SEGY_INVALID_FIELD;
     }
 
@@ -1662,7 +1571,7 @@ int segy_offsets( segy_file* fp,
      * check that field value is sane, so that we don't have to check
      * segy_get_field's error
      */
-    if( field_size[ il ] == 0 || field_size[ xl ] == 0 )
+    if( tr_field_type[ il ] == 0 || tr_field_type[ xl ] == 0 )
         return SEGY_INVALID_FIELD;
 
     err = segy_traceheader( fp, 0, header, trace0, trace_bsize );
@@ -1696,7 +1605,7 @@ int segy_offset_indices( segy_file* fp,
     int32_t x = 0;
     char header[ SEGY_TRACE_HEADER_SIZE ];
 
-    if( field_size[ offset_field ] == 0 )
+    if( tr_field_type[ offset_field ] == 0 )
         return SEGY_INVALID_FIELD;
 
     for( int i = 0; i < offsets; ++i ) {

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -735,36 +735,36 @@ int segy_get_bfield( const char* binheader, int field, int32_t* val ) {
 static int set_field( char* header,
                       const segy_field_data* fd ) {
 
-    segy_field_data w_fd = *fd;
+    segy_field_value fv = fd->value;
 
-    switch ( w_fd.datatype ) {
+    switch ( fd->datatype ) {
 
         case SEGY_SIGNED_INTEGER_4_BYTE:
-            w_fd.value.i32 = htobe32( w_fd.value.i32 );
-            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.i32), formatsize( w_fd.datatype ));
+            fv.i32 = htobe32( fv.i32 );
+            memcpy( header + (fd->field_index - 1), &(fv.i32), formatsize( fd->datatype ));
             return SEGY_OK;
 
         case SEGY_SIGNED_SHORT_2_BYTE:
-            w_fd.value.i16 = htobe16( w_fd.value.i16 );
-            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.i16), formatsize( w_fd.datatype ));
+            fv.i16 = htobe16( fv.i16 );
+            memcpy( header + (fd->field_index - 1), &(fv.i16), formatsize( fd->datatype ));
             return SEGY_OK;
 
         case SEGY_SIGNED_CHAR_1_BYTE:
-            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.i8), formatsize( w_fd.datatype ));
+            memcpy( header + (fd->field_index - 1), &(fv.i8), formatsize( fd->datatype ));
             return SEGY_OK;
 
         case SEGY_UNSIGNED_INTEGER_4_BYTE:
-            w_fd.value.u32 = htobe32( w_fd.value.u32 );
-            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.u32), formatsize( w_fd.datatype ));
+            fv.u32 = htobe32( fv.u32 );
+            memcpy( header + (fd->field_index - 1), &(fv.u32), formatsize( fd->datatype ));
             return SEGY_OK;
 
         case SEGY_UNSIGNED_SHORT_2_BYTE:
-            w_fd.value.u16 = htobe16( w_fd.value.u16 );
-            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.u16), formatsize( w_fd.datatype ));
+            fv.u16 = htobe16( fv.u16 );
+            memcpy( header + (fd->field_index - 1), &(fv.u16), formatsize( fd->datatype ));
             return SEGY_OK;
 
         case SEGY_UNSIGNED_CHAR_1_BYTE:
-            memcpy( header + (w_fd.field_index - 1), &(w_fd.value.u8), formatsize( w_fd.datatype ));
+            memcpy( header + (fd->field_index - 1), &(fv.u8), formatsize( fd->datatype ));
             return SEGY_OK;
 
         default:

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -302,7 +302,153 @@ static int field_size[SEGY_TRACE_HEADER_SIZE] = {
     [SEGY_TR_YEAR_DATA_REC          ] = 2,
 };
 
+/*
+    Lookup table for segy field data types. Types are defined in the SEGY_FORMAT enum.
+    All values not explicitly set are 0 which is undefined in the SEGY_FORMAT.
+*/
+static uint8_t tr_field_type[SEGY_TRACE_HEADER_SIZE] = {
+    [SEGY_TR_SEQ_LINE               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SEQ_FILE               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_FIELD_RECORD           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_NUMBER_ORIG_FIELD      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_ENERGY_SOURCE_POINT    ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_ENSEMBLE               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_NUM_IN_ENSEMBLE        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_TRACE_ID               ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SUMMED_TRACES          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_STACKED_TRACES         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DATA_USE               ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_OFFSET                 ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_RECV_GROUP_ELEV        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_SURF_ELEV       ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_DEPTH           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_RECV_DATUM_ELEV        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_DATUM_ELEV      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_WATER_DEPTH     ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_GROUP_WATER_DEPTH      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_ELEV_SCALAR            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_GROUP_SCALAR    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_X               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_Y               ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_GROUP_X                ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_GROUP_Y                ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_COORD_UNITS            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_WEATHERING_VELO        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SUBWEATHERING_VELO     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_UPHOLE_TIME     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GROUP_UPHOLE_TIME      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_STATIC_CORR     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GROUP_STATIC_CORR      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TOT_STATIC_APPLIED     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LAG_A                  ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LAG_B                  ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DELAY_REC_TIME         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MUTE_TIME_START        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MUTE_TIME_END          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SAMPLE_COUNT           ] = SEGY_UNSIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SAMPLE_INTER           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GAIN_TYPE              ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_INSTR_GAIN_CONST       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_INSTR_INIT_GAIN        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_CORRELATED             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_FREQ_START       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_FREQ_END         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_LENGTH           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_TYPE             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_TAPERLEN_START   ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SWEEP_TAPERLEN_END     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TAPER_TYPE             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_ALIAS_FILT_FREQ        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_ALIAS_FILT_SLOPE       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_NOTCH_FILT_FREQ        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_NOTCH_FILT_SLOPE       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LOW_CUT_FREQ           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_HIGH_CUT_FREQ          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_LOW_CUT_SLOPE          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_HIGH_CUT_SLOPE         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_YEAR_DATA_REC          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DAY_OF_YEAR            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_HOUR_OF_DAY            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MIN_OF_HOUR            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SEC_OF_MIN             ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TIME_BASE_CODE         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_WEIGHTING_FAC          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GEOPHONE_GROUP_ROLL1   ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GEOPHONE_GROUP_FIRST   ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GEOPHONE_GROUP_LAST    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_GAP_SIZE               ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_OVER_TRAVEL            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_CDP_X                  ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_CDP_Y                  ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_INLINE                 ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_CROSSLINE              ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SHOT_POINT             ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SHOT_POINT_SCALAR      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_MEASURE_UNIT           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TRANSDUCTION_MANT      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_TRANSDUCTION_EXP       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_TRANSDUCTION_UNIT      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_DEVICE_ID              ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SCALAR_TRACE_HEADER    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_TYPE            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_ENERGY_DIR_VERT ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_ENERGY_DIR_XLINE] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_ENERGY_DIR_ILINE] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_MEASURE_MANT    ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_SOURCE_MEASURE_EXP     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_SOURCE_MEASURE_UNIT    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [SEGY_TR_UNASSIGNED1            ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [SEGY_TR_UNASSIGNED2            ] = SEGY_SIGNED_INTEGER_4_BYTE,
+};
+
+
 #define HEADER_SIZE SEGY_TEXT_HEADER_SIZE
+
+/*
+    Lookup table for segy binary field data types. Types are defined in the SEGY_FORMAT enum.
+    All values not explicitly set are 0 which is undefined in the SEGY_FORMAT.
+*/
+static uint8_t bin_field_type[SEGY_BINARY_HEADER_SIZE] = {
+    [- HEADER_SIZE + SEGY_BIN_JOB_ID                ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_LINE_NUMBER           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_REEL_NUMBER           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_TRACES                ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_AUX_TRACES            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_INTERVAL              ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_INTERVAL_ORIG         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SAMPLES               ] = SEGY_UNSIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SAMPLES_ORIG          ] = SEGY_UNSIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_FORMAT                ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_ENSEMBLE_FOLD         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SORTING_CODE          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_VERTICAL_SUM          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_START      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_FREQ_END        ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_LENGTH          ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP                 ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_CHANNEL         ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_START     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SWEEP_TAPER_END       ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_TAPER                 ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_CORRELATED_TRACES     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_BIN_GAIN_RECOVERY     ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_AMPLITUDE_RECOVERY    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_MEASUREMENT_SYSTEM    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_IMPULSE_POLARITY      ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_VIBRATORY_POLARITY    ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_TRACES            ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_AUX_TRACES        ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES           ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_SAMPLES_ORIG      ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_ENSEMBLE_FOLD     ] = SEGY_SIGNED_INTEGER_4_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED1           ] = SEGY_NOT_IN_USE_1,
+    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION         ] = SEGY_UNSIGNED_CHAR_1_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_SEGY_REVISION_MINOR   ] = SEGY_UNSIGNED_CHAR_1_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_TRACE_FLAG            ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_EXT_HEADERS           ] = SEGY_SIGNED_SHORT_2_BYTE,
+    [- HEADER_SIZE + SEGY_BIN_UNASSIGNED2           ] = SEGY_NOT_IN_USE_1,
+};
+
 
 /*
  * Supporting same byte offsets as in the segy specification, i.e. from the
@@ -629,52 +775,105 @@ no_mmap:
     return err;
 }
 
-static int get_field( const char* header,
-                      const int* table,
-                      int field,
-                      int32_t* f ) {
+static int get_field( const char* header, segy_field_data* fd) {
 
-    const int bsize = table[ field ];
-    uint32_t buf32 = 0;
-    uint16_t buf16 = 0;
-    uint8_t  buf8  = 0;
+    switch ( fd->datatype ) {
 
-    switch( bsize ) {
-        case 4:
-            memcpy( &buf32, header + (field - 1), 4 );
-            *f = (int32_t)be32toh( buf32 );
+        case SEGY_SIGNED_INTEGER_4_BYTE:
+            memcpy( &(fd->value.i32), header + (fd->field_index -1), formatsize( fd->datatype ) );
+            fd->value.i32 = be32toh( fd->value.i32 );
             return SEGY_OK;
 
-        case 2:
-            memcpy( &buf16, header + (field - 1), 2 );
-            *f = (int16_t)be16toh( buf16 );
+        case SEGY_SIGNED_SHORT_2_BYTE:
+            memcpy( &(fd->value.i16), header + (fd->field_index -1), formatsize( fd->datatype ) );
+            fd->value.i16 = be16toh( fd->value.i16 );
             return SEGY_OK;
 
-        case 1:
-            memcpy(&buf8, header + (field - 1), 1);
-            *f = buf8;
+        case SEGY_SIGNED_CHAR_1_BYTE:
+            memcpy( &(fd->value.i8), header + (fd->field_index -1), formatsize( fd->datatype ) );
             return SEGY_OK;
 
-        case 0:
+        case SEGY_UNSIGNED_SHORT_2_BYTE:
+            memcpy( &(fd->value.u16), header + (fd->field_index -1), formatsize( fd->datatype ) );
+            fd->value.u16 = be16toh( fd->value.u16 );
+            return SEGY_OK;
+
+        case SEGY_UNSIGNED_CHAR_1_BYTE:
+            memcpy( &(fd->value.u8), header + (fd->field_index -1), formatsize( fd->datatype ) );
+            return SEGY_OK;
+
         default:
             return SEGY_INVALID_FIELD;
     }
 }
 
-int segy_get_field( const char* traceheader, int field, int* f ) {
-    if( field < 0 || field >= SEGY_TRACE_HEADER_SIZE )
-        return SEGY_INVALID_FIELD;
+static int fd_get_int( const segy_field_data* fd, int* val ) {
+    switch( fd->datatype ) {
 
-    return get_field( traceheader, field_size, field, f );
+        case SEGY_SIGNED_INTEGER_4_BYTE:
+            *val = fd->value.i32;
+            return SEGY_OK;
+
+        case SEGY_SIGNED_SHORT_2_BYTE:
+            *val = fd->value.i16;
+            return SEGY_OK;
+
+        case SEGY_SIGNED_CHAR_1_BYTE:
+            *val = fd->value.i8;
+            return SEGY_OK;
+
+        case SEGY_UNSIGNED_SHORT_2_BYTE:
+            *val = fd->value.u16;
+            return SEGY_OK;
+
+        case SEGY_UNSIGNED_CHAR_1_BYTE:
+            *val = fd->value.u8;
+            return SEGY_OK;
+
+        default:
+            return SEGY_INVALID_FIELD;
+    }
 }
 
-int segy_get_bfield( const char* binheader, int field, int32_t* f ) {
-    field -= SEGY_TEXT_HEADER_SIZE;
-
-    if( field < 0 || field >= SEGY_BINARY_HEADER_SIZE )
+static int init_segy_field_data(int field, segy_field_data* fd) {
+    if ( field > 0 && field < SEGY_TRACE_HEADER_SIZE ) {
+        fd->field_index = field;
+        fd->field_offset = 0;
+        fd->datatype = tr_field_type[ fd->field_index ];
+    }        
+    else if ( field > SEGY_TEXT_HEADER_SIZE && field < SEGY_TEXT_HEADER_SIZE + SEGY_BINARY_HEADER_SIZE ) {
+        fd->field_index = field - SEGY_TEXT_HEADER_SIZE;
+        fd->field_offset = SEGY_TEXT_HEADER_SIZE;
+        fd->datatype = bin_field_type[ fd->field_index ];
+    }
+    else
         return SEGY_INVALID_FIELD;
+    if ( fd->datatype == SEGY_UNDEFINED_FIELD )
+        return SEGY_INVALID_FIELD;
+    return SEGY_OK;
+}
 
-    return get_field( binheader, bfield_size, field, f );
+int segy_get_field( const char* traceheader, int field, int* val ) {
+
+    segy_field_data fd;
+    int err = init_segy_field_data( field, &fd );
+    if ( err != SEGY_OK ) return err;
+
+    err = get_field( traceheader, &fd );
+    if ( err != SEGY_OK ) return err;
+    err = fd_get_int( &fd, val );
+    return err;
+}
+
+int segy_get_bfield( const char* binheader, int field, int32_t* val ) {
+
+    segy_field_data fd;
+    int err = init_segy_field_data( field, &fd );
+    if ( err != SEGY_OK ) return err;
+
+    err = get_field( binheader, &fd );
+    if ( err != SEGY_OK ) return err;
+    return fd_get_int( &fd, val );
 }
 
 static int set_field( char* header, const int* table, int field, int32_t val ) {
@@ -783,10 +982,6 @@ int segy_field_forall( segy_file* fp,
     err = segy_get_field( header, field, &f );
     if( err != SEGY_OK ) return SEGY_INVALID_ARGS;
 
-    // since segy_get_field didn't fail earlier, it is safe to look up the word
-    // size
-    const int word_size = field_size[field];
-
     int slicelen = slicelength( start, stop, step );
 
     // check *once* that we don't look past the end-of-file
@@ -803,8 +998,15 @@ int segy_field_forall( segy_file* fp,
     if( fp->addr ) {
         for( int i = start; slicelen > 0; i += step, ++buf, --slicelen ) {
             segy_seek( fp, i, trace0, trace_bsize );
-            get_field( fp->cur, field_size, field, &f );
-            if (lsb) f = bswap_header_word(f, word_size);
+
+            segy_field_data fd;
+            err = init_segy_field_data(field, &fd);
+            if ( err != SEGY_OK ) return err;
+            err = get_field( fp->cur, &fd );
+            if( err != 0 ) return err;
+            err = fd_get_int( &fd, &f );
+            if( err != 0 ) return err;
+            if (lsb) f = bswap_header_word(f, formatsize( fd.datatype ));
             *buf = f;
         }
 
@@ -824,12 +1026,18 @@ int segy_field_forall( segy_file* fp,
     const int zfield = field - 1;
     for( int i = start; slicelen > 0; i += step, ++buf, --slicelen ) {
         err = segy_seek( fp, i, trace0 + zfield, trace_bsize );
-        if( err != 0 ) return SEGY_FSEEK_ERROR;
+        if( err != 0 ) return err;
         size_t readc = fread( header + zfield, sizeof(uint32_t), 1, fp->fp );
         if( readc != 1 ) return SEGY_FREAD_ERROR;
 
-        get_field( header, field_size, field, &f );
-        if (lsb) f = bswap_header_word(f, word_size);
+        segy_field_data fd;
+        err = init_segy_field_data(field, &fd);
+        if ( err != SEGY_OK ) return err;
+        err = get_field( header, &fd );
+        if( err != 0 ) return err;
+        err = fd_get_int( &fd, &f );
+        if( err != 0 ) return err;
+        if (lsb) f = bswap_header_word(f, formatsize( fd.datatype ));
         *buf = f;
     }
 

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -71,6 +71,7 @@ struct Err {
     static Err ok()    { return SEGY_OK; }
     static Err args()  { return SEGY_INVALID_ARGS; }
     static Err field() { return SEGY_INVALID_FIELD; }
+    static Err value() { return SEGY_INVALID_FIELD_VALUE; }
 
     int err;
 };
@@ -2049,5 +2050,32 @@ TEST_CASE("segy_get_field reads values correctly",  "[c.segy]" ) {
         Err err = segy_get_field( header, SEGY_TR_TRACE_ID, &read_value );
         CHECK( success( err ) );
         CHECK( read_value == value );
+    }
+}
+
+TEST_CASE("segy_set_field write values correctly",  "[c.segy]" ) {
+
+    char header[ SEGY_TRACE_HEADER_SIZE ] = { 0 };
+
+    SECTION("test edge cases int16") {
+        int16_t value = GENERATE(0, 1, -1, 0x0102, 0x0201, -32767, -32766);
+        Err err = segy_set_field( header, SEGY_TR_TRACE_ID, value );
+        CHECK( err == Err::ok() );
+
+        uint8_t b0 = header[SEGY_TR_TRACE_ID-0];
+        uint8_t b1 = header[SEGY_TR_TRACE_ID-1];
+        uint16_t read_value = b1<<8 | b0;
+        CHECK( read_value == (uint16_t)value );
+    }
+}
+
+TEST_CASE("segy_set_field write invalid value",  "[c.segy]" ) {
+
+    char header[ SEGY_TRACE_HEADER_SIZE ] = { 0 };
+
+    SECTION("test value outside of int16 range") {
+        int32_t value = 0xFFFF + 1;
+        Err err = segy_set_field( header, SEGY_TR_TRACE_ID, value );
+        CHECK( err == Err::value() );
     }
 }

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -2033,3 +2033,21 @@ TEST_CASE("segy_samples uses ext-samples word", "[c.segy]") {
         CHECK(samples == 1);
     }
 }
+
+TEST_CASE("segy_get_field reads values correctly",  "[c.segy]" ) {
+
+    char header[ SEGY_TRACE_HEADER_SIZE ] = { 0 };
+
+    SECTION("test edge cases int16") {
+        int16_t value = GENERATE(0, 1, -1, 0x0102, 0x0201, -32767, -32766);
+        uint8_t b0 = 0xFF & ((uint16_t)value >> 0);
+        uint8_t b1 = 0xFF & ((uint16_t)value >> 8);
+        header[SEGY_TR_TRACE_ID-1] = b1;
+        header[SEGY_TR_TRACE_ID-0] = b0;
+
+        int32_t read_value;
+        Err err = segy_get_field( header, SEGY_TR_TRACE_ID, &read_value );
+        CHECK( success( err ) );
+        CHECK( read_value == value );
+    }
+}


### PR DESCRIPTION
Reading and writing values to the trace header and binary file header only used the datatype size and not the type. In this PR the tables are updated to store data type. The datatype will enable the access of float fields in the future. 

Currently the "Benchmark" test is writing int values that are greater than 2^16 to int16 fields. This raises an exception and causes the Benchmark test to fail. It should be possible to review this PR and then postponed the merge step until this issue is resolved. 