### PR TITLE
Fix of recently failing CI

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cibuildwheel
-        run: python3 -m pip install cibuildwheel
+        # old ref is incompatible with cmake 4.0.0, which is used in cbuildwheel > 2.23.2
+        # once default ref is updated, restriction can be removed
+        run: python3 -m pip install cibuildwheel==2.23.2
 
       - name: Install build/test dependencies
         working-directory: python

--- a/python/examples/make-file.py
+++ b/python/examples/make-file.py
@@ -48,10 +48,6 @@ def main():
                 f.trace[tr] = trace + (xl / 100.0) + il
                 tr += 1
 
-        f.bin.update(
-            tsort=segyio.TraceSortingFormat.INLINE_SORTING
-        )
-
 
 if __name__ == '__main__':
     main()

--- a/python/examples/make-ps-file.py
+++ b/python/examples/make-ps-file.py
@@ -55,9 +55,5 @@ def main():
                     f.trace[tr] = trace + (xl / 100.0) + il + (off * 100)
                     tr += 1
 
-        f.bin.update(
-            tsort=segyio.TraceSortingFormat.INLINE_SORTING
-        )
-
 if __name__ == '__main__':
     main()

--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -225,24 +225,31 @@ def create(filename, spec):
     else:
         interval = int((samples[1] - samples[0]) * 1000)
 
-    f.bin.update(
-        ntrpr    = tracecount,
-        nart     = tracecount,
+    binary_header = {}
+    binary_header.update(
+        ntrpr    = 1,
         hdt      = interval,
         dto      = interval,
-        hns      = len(samples),
-        nso      = len(samples),
         format   = int(spec.format),
+        fold     = 1,
+        tsort    = 4,
         exth     = ext_headers,
     )
 
     if len(samples) > 2**16 - 1:
         # when using the ext-samples field, also set rev2, even though it's a
         # soft lie and files aren't really compliant
-        f.bin.update(
+        binary_header.update(
             exthns = len(samples),
             extnso = len(samples),
             rev    = 2
         )
+    else:
+        binary_header.update(
+            hns = len(samples),
+            nso = len(samples),
+        )
+
+    f.bin.update(**binary_header)
 
     return f

--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -516,7 +516,6 @@ def from_array(filename, data, iline=189,
                     tr += 1
 
         f.bin.update(
-            tsort=TraceSortingFormat.INLINE_SORTING,
             hdt=dt,
             dto=dt
         )

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -329,8 +329,6 @@ def test_from_array3D(tmpdir, create):
             assert list(g.attributes(TraceField.TRACE_SAMPLE_COUNT)) == list(
                 50 * np.ones(25))
 
-            assert g.bin[BinField.SortingCode] == 2
-
 
 @pytest.mark.parametrize("create", [createfrom4d, createfromany])
 def test_from_array4D(tmpdir, create):


### PR DESCRIPTION
- Today's benchmark test fixes
- Fixes to the binary header values

Note: I suspect that file creation through `tools.from_array` might fail for users as set trace fields are 2 bytes (trace number, sample count). We just don't have big enough tests to confirm this. Probably would be best to create them one we have extended trace headers in place.