### PR TITLE
Remove bfield and trfield

### DIFF
--- a/applications/apputils.c
+++ b/applications/apputils.c
@@ -35,22 +35,6 @@ int parseint( const char* str, int* x ) {
     return 0;
 }
 
-int bfield( const char* header, int field ) {
-    int32_t f;
-    int err = segy_get_field_int( header, field, &f );
-
-    if( err ) return -1;
-    return f;
-}
-
-int trfield( const char* header, int field ) {
-    int32_t f;
-    int err = segy_get_field_int( header, field, &f );
-
-    if( err ) return -1;
-    return f;
-}
-
 int printversion( const char* name ) {
     printf( "%s (segyio version %d.%d)\n", name, segyio_MAJOR, segyio_MINOR );
     return 0;

--- a/applications/apputils.h
+++ b/applications/apputils.h
@@ -4,8 +4,6 @@
 int errmsg( int errcode, const char* msg );
 int errmsg2( int errcode, const char* prelude, const char* msg );
 int parseint( const char* str, int* x );
-int bfield( const char* header, int field );
-int trfield( const char* header, int field );
 int printversion( const char* name );
 
 #endif //SEGYIO_APPUTILS_H


### PR DESCRIPTION
In preparation for reading fields with data type float I want to simplify the code. 

Functions bfield and trfield returns -1 in case of error. For most fields -1 is a valid value. Not all cases using these functions check for -1. Remove the functions and ignore the error code in cases it is not checked.
