### PR TITLE
Rename entities to reflect broader io support

### DIFF
--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -194,7 +194,7 @@ def create(filename, spec):
         endian = 'big'
 
 
-    fd = _segyio.segyiofd(str(filename), 'w+', c_endianness(endian))
+    fd = _segyio.segyfd(str(filename), 'w+', c_endianness(endian))
     fd.segymake(
         samples = len(samples),
         tracecount = tracecount,

--- a/python/segyio/depth.py
+++ b/python/segyio/depth.py
@@ -37,17 +37,17 @@ class Depth(Sequence):
         depths, consider using a faster mode.
     """
 
-    def __init__(self, fd):
-        super(Depth, self).__init__(len(fd.samples))
-        self.filehandle = fd.xfd
-        self.dtype = fd.dtype
+    def __init__(self, segyfile):
+        super(Depth, self).__init__(len(segyfile.samples))
+        self.segyfd = segyfile.segyfd
+        self.dtype = segyfile.dtype
 
-        if fd.unstructured:
-            self.shape = fd.tracecount
+        if segyfile.unstructured:
+            self.shape = segyfile.tracecount
             self.offsets = 1
         else:
-            self.shape = (len(fd.fast), len(fd.slow))
-            self.offsets = len(fd.offsets)
+            self.shape = (len(segyfile.fast), len(segyfile.slow))
+            self.offsets = len(segyfile.offsets)
 
     def __getitem__(self, i):
         """depth[i]
@@ -116,7 +116,7 @@ class Depth(Sequence):
         try:
             i = self.wrapindex(i)
             buf = np.empty(self.shape, dtype=self.dtype)
-            return self.filehandle.getdepth(i, buf.size, self.offsets, buf)
+            return self.segyfd.getdepth(i, buf.size, self.offsets, buf)
 
         except TypeError:
             try:
@@ -130,7 +130,7 @@ class Depth(Sequence):
                 y = np.copy(x)
 
                 for j in range(*indices):
-                    self.filehandle.getdepth(j, x.size, self.offsets, x)
+                    self.segyfd.getdepth(j, x.size, self.offsets, x)
                     x, y = y, x
                     yield y
 
@@ -177,4 +177,4 @@ class Depth(Sequence):
             return
 
         val = castarray(val, dtype = self.dtype)
-        self.filehandle.putdepth(depth, val.size, self.offsets, val)
+        self.segyfd.putdepth(depth, val.size, self.offsets, val)

--- a/python/segyio/line.py
+++ b/python/segyio/line.py
@@ -61,13 +61,13 @@ class Line(Mapping):
         common dict operations (Mapping)
     """
 
-    def __init__(self, filehandle, labels, length, stride, offsets, name):
-        self.filehandle = filehandle.xfd
+    def __init__(self, segyfile, labels, length, stride, offsets, name):
+        self.segyfd = segyfile.segyfd
         self.lines = labels
         self.length = length
         self.stride = stride
-        self.shape = (length, len(filehandle.samples))
-        self.dtype = filehandle.dtype
+        self.shape = (length, len(segyfile.samples))
+        self.dtype = segyfile.dtype
 
         # pre-compute all line beginnings
         from ._segyio import fread_trace0
@@ -198,7 +198,7 @@ class Line(Mapping):
         # prioritise the code path that's potentially in loops externally
         if not isinstance(index, slice) and not isinstance(offset, slice):
             head = self.heads[index] + self.offsets[offset]
-            return self.filehandle.getline(head,
+            return self.segyfd.getline(head,
                                            self.length,
                                            self.stride,
                                            len(self.offsets),
@@ -220,7 +220,7 @@ class Line(Mapping):
             for line in irange:
                 for off in orange:
                     head = self.heads[line] + self.offsets[off]
-                    self.filehandle.getline(head,
+                    self.segyfd.getline(head,
                                             self.length,
                                             self.stride,
                                             len(self.offsets),
@@ -284,7 +284,7 @@ class Line(Mapping):
 
         if not isinstance(index, slice) and not isinstance(offset, slice):
             head = self.heads[index] + self.offsets[offset]
-            return self.filehandle.putline(head,
+            return self.segyfd.putline(head,
                                            self.length,
                                            self.stride,
                                            len(self.offsets),
@@ -299,7 +299,7 @@ class Line(Mapping):
         for line in irange:
             for off in orange:
                 head = self.heads[line] + self.offsets[off]
-                try: self.filehandle.putline(head,
+                try: self.segyfd.putline(head,
                                             self.length,
                                             self.stride,
                                             len(self.offsets),
@@ -357,7 +357,7 @@ class HeaderLine(Line):
     # __len__, keys() etc., however, the __getitem__ is  way different and is re-implemented
 
     def __init__(self, header, base, direction):
-        super(HeaderLine, self).__init__(header.segy,
+        super(HeaderLine, self).__init__(header.segyfile,
                                           base.lines,
                                           base.length,
                                           base.stride,

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -6,7 +6,7 @@ from .utils import c_endianness
 
 def infer_geometry(f, metrics, iline, xline, strict):
     try:
-        cube_metrics = f.xfd.cube_metrics(iline, xline)
+        cube_metrics = f.segyfd.cube_metrics(iline, xline)
         f._sorting   = cube_metrics['sorting']
         iline_count  = cube_metrics['iline_count']
         xline_count  = cube_metrics['xline_count']
@@ -17,7 +17,7 @@ def infer_geometry(f, metrics, iline, xline, strict):
         xlines  = numpy.zeros(xline_count,  dtype=numpy.intc)
         offsets = numpy.zeros(offset_count, dtype=numpy.intc)
 
-        f.xfd.indices(metrics, ilines, xlines, offsets)
+        f.segyfd.indices(metrics, ilines, xlines, offsets)
         f.interpret(ilines, xlines, offsets, f._sorting)
 
     except:

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -149,7 +149,7 @@ def open(filename, mode="r", iline = 189,
         raise ValueError(', '.join((problem, solution)))
 
     from . import _segyio
-    fd = _segyio.segyiofd(str(filename), mode, c_endianness(endian))
+    fd = _segyio.segyfd(str(filename), mode, c_endianness(endian))
     fd.segyopen()
     metrics = fd.metrics()
 

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -46,8 +46,8 @@ class SegyFile(object):
         self._xline_length = None
         self._xline_stride = None
 
-        self.xfd = fd
-        metrics = self.xfd.metrics()
+        self.segyfd = fd
+        metrics = self.segyfd.metrics()
         self._fmt = metrics['format']
         self._tracecount = metrics['tracecount']
         self._ext_headers = metrics['ext_headers']
@@ -74,7 +74,7 @@ class SegyFile(object):
             self._fmt = 1
             self._dtype = np.dtype(np.float32)
 
-        self._trace = Trace(self.xfd,
+        self._trace = Trace(self.segyfd,
                             self.dtype,
                             self.tracecount,
                             metrics['samplecount'],
@@ -155,7 +155,7 @@ class SegyFile(object):
         ...     f.flush()
 
         """
-        self.xfd.flush()
+        self.segyfd.flush()
 
     def close(self):
         """Close the file
@@ -173,7 +173,7 @@ class SegyFile(object):
 
 
         """
-        self.xfd.close()
+        self.segyfd.close()
 
     def mmap(self):
         """Memory map the file
@@ -219,7 +219,7 @@ class SegyFile(object):
         1.02548
 
         """
-        return self.xfd.mmap()
+        return self.segyfd.mmap()
 
     @property
     def dtype(self):
@@ -414,7 +414,7 @@ class SegyFile(object):
         .. versionadded:: 1.1
 
         """
-        return Attributes(field, self.xfd, self.tracecount)
+        return Attributes(field, self.segyfd, self.tracecount)
 
     @property
     def trace(self):
@@ -767,7 +767,7 @@ class SegyFile(object):
         -----
         .. versionadded:: 1.1
         """
-        return Text(self.xfd, self._ext_headers + 1)
+        return Text(self.segyfd, self._ext_headers + 1)
 
     @property
     def bin(self):

--- a/python/segyio/segyio.cpp
+++ b/python/segyio/segyio.cpp
@@ -174,7 +174,7 @@ void autods::close() {
     this->ds = NULL;
 }
 
-struct segyiofd {
+struct segyfd {
     PyObject_HEAD
     autods ds;
     long trace0;
@@ -231,7 +231,7 @@ struct buffer_guard {
 
 namespace fd {
 
-int init( segyiofd* self, PyObject* args, PyObject* kwargs ) {
+int init( segyfd* self, PyObject* args, PyObject* kwargs ) {
     char* filename = NULL;
     char* mode = NULL;
     int endian = 0;
@@ -282,7 +282,7 @@ int init( segyiofd* self, PyObject* args, PyObject* kwargs ) {
     return 0;
 }
 
-PyObject* segyopen( segyiofd* self ) {
+PyObject* segyopen( segyfd* self ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -357,7 +357,7 @@ PyObject* segyopen( segyiofd* self ) {
     return (PyObject*) self;
 }
 
-PyObject* segycreate( segyiofd* self, PyObject* args, PyObject* kwargs ) {
+PyObject* segycreate( segyfd* self, PyObject* args, PyObject* kwargs ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -468,7 +468,7 @@ PyObject* segycreate( segyiofd* self, PyObject* args, PyObject* kwargs ) {
     return (PyObject*) self;
 }
 
-PyObject* suopen( segyiofd* self, PyObject* args ) {
+PyObject* suopen( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -525,12 +525,12 @@ PyObject* suopen( segyiofd* self, PyObject* args ) {
     return (PyObject*) self;
 }
 
-void dealloc( segyiofd* self ) {
+void dealloc( segyfd* self ) {
     self->ds.close();
     Py_TYPE( self )->tp_free( (PyObject*) self );
 }
 
-PyObject* close( segyiofd* self ) {
+PyObject* close( segyfd* self ) {
     /* multiple close() is a no-op */
     if( !self->ds ) return Py_BuildValue( "" );
 
@@ -542,7 +542,7 @@ PyObject* close( segyiofd* self ) {
     return Py_BuildValue( "" );
 }
 
-PyObject* flush( segyiofd* self ) {
+PyObject* flush( segyfd* self ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -553,7 +553,7 @@ PyObject* flush( segyiofd* self ) {
     return Py_BuildValue( "" );
 }
 
-PyObject* mmap( segyiofd* self ) {
+PyObject* mmap( segyfd* self ) {
     segy_datasource* ds = self->ds;
 
     if( !ds ) return NULL;
@@ -591,7 +591,7 @@ private:
     heapbuffer( const heapbuffer& );
 };
 
-PyObject* gettext( segyiofd* self, PyObject* args ) {
+PyObject* gettext( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -613,7 +613,7 @@ PyObject* gettext( segyiofd* self, PyObject* args ) {
     return PyByteArray_FromStringAndSize(buffer, segy_textheader_size() - 1);
 }
 
-PyObject* puttext( segyiofd* self, PyObject* args ) {
+PyObject* puttext( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -637,7 +637,7 @@ PyObject* puttext( segyiofd* self, PyObject* args ) {
     return Py_BuildValue( "" );
 }
 
-PyObject* getbin( segyiofd* self ) {
+PyObject* getbin( segyfd* self ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -649,7 +649,7 @@ PyObject* getbin( segyiofd* self ) {
     return PyByteArray_FromStringAndSize( buffer, sizeof( buffer ) );
 }
 
-PyObject* putbin( segyiofd* self, PyObject* args ) {
+PyObject* putbin( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -670,7 +670,7 @@ PyObject* putbin( segyiofd* self, PyObject* args ) {
     return Py_BuildValue( "" );
 }
 
-PyObject* getth( segyiofd* self, PyObject *args ) {
+PyObject* getth( segyfd* self, PyObject *args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -706,7 +706,7 @@ PyObject* getth( segyiofd* self, PyObject *args ) {
     }
 }
 
-PyObject* putth( segyiofd* self, PyObject* args ) {
+PyObject* putth( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -739,7 +739,7 @@ PyObject* putth( segyiofd* self, PyObject* args ) {
     }
 }
 
-PyObject* field_forall( segyiofd* self, PyObject* args ) {
+PyObject* field_forall( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -774,7 +774,7 @@ PyObject* field_forall( segyiofd* self, PyObject* args ) {
     return bufferobj;
 }
 
-PyObject* field_foreach( segyiofd* self, PyObject* args ) {
+PyObject* field_foreach( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -812,7 +812,7 @@ PyObject* field_foreach( segyiofd* self, PyObject* args ) {
     return bufferobj;
 }
 
-PyObject* metrics( segyiofd* self ) {
+PyObject* metrics( segyfd* self ) {
     static const int text = SEGY_TEXT_HEADER_SIZE;
     static const int bin  = SEGY_BINARY_HEADER_SIZE;
     const int ext = (self->trace0 - (text + bin)) / text;
@@ -845,7 +845,7 @@ struct metrics_errmsg {
     }
 };
 
-PyObject* cube_metrics( segyiofd* self, PyObject* args ) {
+PyObject* cube_metrics( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -906,7 +906,7 @@ long getitem( PyObject* dict, const char* key ) {
     return PyLong_AsLong( PyDict_GetItemString( dict, key ) );
 }
 
-PyObject* indices( segyiofd* self, PyObject* args ) {
+PyObject* indices( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -978,7 +978,7 @@ PyObject* indices( segyiofd* self, PyObject* args ) {
     return Py_BuildValue( "" );
 }
 
-PyObject* gettr( segyiofd* self, PyObject* args ) {
+PyObject* gettr( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1027,7 +1027,7 @@ PyObject* gettr( segyiofd* self, PyObject* args ) {
     return bufferobj;
 }
 
-PyObject* puttr( segyiofd* self, PyObject* args ) {
+PyObject* puttr( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1064,7 +1064,7 @@ PyObject* puttr( segyiofd* self, PyObject* args ) {
     }
 }
 
-PyObject* getline( segyiofd* self, PyObject* args) {
+PyObject* getline( segyfd* self, PyObject* args) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1101,7 +1101,7 @@ PyObject* getline( segyiofd* self, PyObject* args) {
     return bufferobj;
 }
 
-PyObject* putline( segyiofd* self, PyObject* args) {
+PyObject* putline( segyfd* self, PyObject* args) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1155,7 +1155,7 @@ PyObject* putline( segyiofd* self, PyObject* args) {
     }
 }
 
-PyObject* getdepth( segyiofd* self, PyObject* args ) {
+PyObject* getdepth( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1204,7 +1204,7 @@ PyObject* getdepth( segyiofd* self, PyObject* args ) {
     return bufferobj;
 }
 
-PyObject* putdepth( segyiofd* self, PyObject* args ) {
+PyObject* putdepth( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1259,7 +1259,7 @@ PyObject* putdepth( segyiofd* self, PyObject* args ) {
     return Py_BuildValue( "" );
 }
 
-PyObject* getdt( segyiofd* self, PyObject* args ) {
+PyObject* getdt( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1295,7 +1295,7 @@ PyObject* getdt( segyiofd* self, PyObject* args ) {
     return Error( err );
 }
 
-PyObject* rotation( segyiofd* self, PyObject* args ) {
+PyObject* rotation( segyfd* self, PyObject* args ) {
     segy_datasource* ds = self->ds;
     if( !ds ) return NULL;
 
@@ -1368,10 +1368,10 @@ PyMethodDef methods [] = {
 
 }
 
-PyTypeObject Segyiofd = {
+PyTypeObject Segyfd = {
     PyVarObject_HEAD_INIT( NULL, 0 )
     "_segyio.segyfd",               /* name */
-    sizeof( segyiofd ),             /* basic size */
+    sizeof( segyfd ),             /* basic size */
     0,                              /* tp_itemsize */
     (destructor)fd::dealloc,        /* tp_dealloc */
     0,                              /* tp_print */
@@ -1604,27 +1604,27 @@ static struct PyModuleDef segyio_module = {
 PyMODINIT_FUNC
 PyInit__segyio(void) {
 
-    Segyiofd.tp_new = PyType_GenericNew;
-    if( PyType_Ready( &Segyiofd ) < 0 ) return NULL;
+    Segyfd.tp_new = PyType_GenericNew;
+    if( PyType_Ready( &Segyfd ) < 0 ) return NULL;
 
     PyObject* m = PyModule_Create(&segyio_module);
 
     if( !m ) return NULL;
 
-    Py_INCREF( &Segyiofd );
-    PyModule_AddObject( m, "segyiofd", (PyObject*)&Segyiofd );
+    Py_INCREF( &Segyfd );
+    PyModule_AddObject( m, "segyfd", (PyObject*)&Segyfd );
 
     return m;
 }
 #else
 PyMODINIT_FUNC
 init_segyio(void) {
-    Segyiofd.tp_new = PyType_GenericNew;
-    if( PyType_Ready( &Segyiofd ) < 0 ) return;
+    Segyfd.tp_new = PyType_GenericNew;
+    if( PyType_Ready( &Segyfd ) < 0 ) return;
 
     PyObject* m = Py_InitModule("_segyio", SegyMethods);
 
-    Py_INCREF( &Segyiofd );
-    PyModule_AddObject( m, "segyiofd", (PyObject*)&Segyiofd );
+    Py_INCREF( &Segyfd );
+    PyModule_AddObject( m, "segyfd", (PyObject*)&Segyfd );
 }
 #endif

--- a/python/segyio/su/file.py
+++ b/python/segyio/su/file.py
@@ -82,7 +82,7 @@ def open(filename, mode = 'r', iline = 189,
         raise ValueError(', '.join((problem, solution)))
 
     from .. import _segyio
-    fd = _segyio.segyiofd(str(filename), mode, c_endianness(endian))
+    fd = _segyio.segyfd(str(filename), mode, c_endianness(endian))
     fd.suopen()
     metrics = fd.metrics()
 

--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -29,7 +29,7 @@ def dt(f, fallback_dt=4000.0):
     .. versionadded:: 1.1
 
     """
-    return f.xfd.getdt(fallback_dt)
+    return f.segyfd.getdt(fallback_dt)
 
 
 def sample_indexes(segyfile, t0=0.0, dt_override=None):
@@ -296,7 +296,7 @@ def rotation(f, line = 'fast'):
     origin = f.header[0][segyio.su.cdpx, segyio.su.cdpy]
     cdpx, cdpy = origin[segyio.su.cdpx], origin[segyio.su.cdpy]
 
-    rot = f.xfd.rotation( len(l),
+    rot = f.segyfd.rotation( len(l),
                           l.stride,
                           len(f.offsets),
                           np.fromiter(l.keys(), dtype = np.intc) )

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -23,21 +23,21 @@ def test_textheader_size():
 
 def test_open_non_existing_file():
     with pytest.raises(IOError):
-        _ = _segyio.segyiofd("non-existing", "r", 0)
+        _ = _segyio.segyfd("non-existing", "r", 0)
 
 
 def test_close_non_existing_file():
     with pytest.raises(TypeError):
-        _segyio.segyiofd.close(None)
+        _segyio.segyfd.close(None)
 
 
 def test_open_and_close_file():
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0)
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
     f.close()
 
 
 def test_open_flush_and_close_file():
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0)
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
     f.flush()
     f.close()
 
@@ -50,7 +50,7 @@ def test_read_text_header_mmap():
 
 
 def test_read_text_header(mmap=False):
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0)
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
     if mmap:
         f.mmap()
 
@@ -79,13 +79,13 @@ def test_read_text_header(mmap=False):
 
 @tmpfiles(testdata / 'small.sgy')
 def test_write_text_header_mmap(tmpdir):
-    f = get_instance_segyiofd(tmpdir)
+    f = get_instance_segyfile(tmpdir)
     write_text_header(f, True)
 
 
 @tmpfiles(testdata / 'small.sgy')
 def test_write_text_header(tmpdir):
-    f = get_instance_segyiofd(tmpdir)
+    f = get_instance_segyfile(tmpdir)
     write_text_header(f, False)
 
 
@@ -107,7 +107,7 @@ def write_text_header(f, mmap):
     f.close()
 
 
-def get_instance_segyiofd(tmpdir,
+def get_instance_segyfile(tmpdir,
                           file_name="small.sgy",
                           mode="r+",
                           samples = None,
@@ -117,20 +117,20 @@ def get_instance_segyiofd(tmpdir,
     f = os.path.join(path, file_name)
 
     if samples is not None:
-        return _segyio.segyiofd(f, mode, 0).segymake(samples, tracecount)
+        return _segyio.segyfd(f, mode, 0).segymake(samples, tracecount)
     else:
-        return _segyio.segyiofd(f, mode, 0).segyopen()
+        return _segyio.segyfd(f, mode, 0).segyopen()
 
 
 @tmpfiles(testdata / 'small.sgy')
 def test_read_and_write_binary_header(tmpdir):
-    f = get_instance_segyiofd(tmpdir)
+    f = get_instance_segyfile(tmpdir)
     read_and_write_binary_header(f, False)
 
 
 @tmpfiles(testdata / 'small.sgy')
 def test_read_and_write_binary_header_mmap(tmpdir):
-    f = get_instance_segyiofd(tmpdir)
+    f = get_instance_segyfile(tmpdir)
     read_and_write_binary_header(f, True)
 
 
@@ -152,7 +152,7 @@ def test_read_binary_header_fields_mmap():
 
 
 def test_read_binary_header_fields(mmap=False):
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0)
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
     if mmap:
         f.mmap()
 
@@ -175,7 +175,7 @@ def test_line_metrics_mmap():
 
 
 def test_line_metrics(mmap=False):
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -219,7 +219,7 @@ def test_metrics_mmap():
 
 
 def test_metrics(mmap=False):
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -251,7 +251,7 @@ def test_indices_mmap():
 
 
 def test_indices(mmap=False):
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -305,7 +305,7 @@ def test_fread_trace0_mmap():
 
 
 def test_fread_trace0(mmap=False):
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -378,13 +378,13 @@ def test_get_and_putfield():
 
 @tmpfiles(testdata / 'small.sgy')
 def test_read_and_write_traceheader_mmap(tmpdir):
-    f = get_instance_segyiofd(tmpdir)
+    f = get_instance_segyfile(tmpdir)
     read_and_write_traceheader(f, True)
 
 
 @tmpfiles(testdata / 'small.sgy')
 def test_read_and_write_traceheader(tmpdir):
-    f = get_instance_segyiofd(tmpdir)
+    f = get_instance_segyfile(tmpdir)
     read_and_write_traceheader(f, False)
 
 
@@ -428,7 +428,7 @@ def read_and_write_traceheader(f, mmap):
 
 
 def test_read_traceheaders():
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
     read_traceheaders_forall(f, False)
     read_traceheaders_forall(f, True)
 
@@ -472,7 +472,7 @@ def read_traceheaders_foreach(f, mmap):
 
 @tmpfiles(testdata / 'small.sgy')
 def test_read_and_write_trace_mmap(tmpdir):
-    f = get_instance_segyiofd(tmpdir,
+    f = get_instance_segyfile(tmpdir,
         "trace-wrt.sgy",
         "w+",
         samples = 25,
@@ -483,7 +483,7 @@ def test_read_and_write_trace_mmap(tmpdir):
 
 @tmpfiles(testdata / 'small.sgy')
 def test_read_and_write_trace(tmpdir):
-    f = get_instance_segyiofd(tmpdir,
+    f = get_instance_segyfile(tmpdir,
             "trace-wrt.sgy",
             "w+",
             samples = 25,
@@ -549,7 +549,7 @@ def read_line(f, metrics, iline_idx, xline_idx):
 
 
 def read_small(mmap=False):
-    f = _segyio.segyiofd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
 
     if mmap:
         f.mmap()


### PR DESCRIPTION
At the moment we have a lot of entities with name "fd" in it, which likely stands for "file descriptor". As we no longer operate on files, but on an abstract datasource, it is better we rename the classes and variables that have some reference to that.


Alex and I agreed that we want to do some name changes due to having broader io support, but we did not agree on the scope.
I believe proposed changes improve situation, but if reviewer has something against new names, will gladly hear it :cat: 
