### PR TITLE
Expose datasources to python bindings

### DIFF
--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -139,6 +139,8 @@ typedef struct {
 
 segy_file* segy_open( const char* path, const char* mode );
 int segy_mmap( segy_datasource* );
+segy_datasource* segy_memopen( unsigned char* addr, size_t size );
+
 int segy_flush( segy_datasource* );
 int segy_close( segy_datasource* );
 

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -774,6 +774,8 @@ typedef enum {
     SEGY_READONLY,
     SEGY_NOTFOUND,
     SEGY_MEMORY_ERROR,
+    SEGY_DS_FLUSH_ERROR,
+    SEGY_DS_CLOSE_ERROR,
     // values are duplicated until enum is properly cleaned
     SEGY_DS_READ_ERROR = SEGY_FREAD_ERROR,
     SEGY_DS_WRITE_ERROR = SEGY_FWRITE_ERROR,

--- a/lib/src/segy.c
+++ b/lib/src/segy.c
@@ -735,7 +735,7 @@ int segy_flush( segy_datasource* ds ) {
     if( !ds->writable ) return SEGY_OK;
 
     int flusherr = ds->flush( ds );
-    if( flusherr != 0 ) return SEGY_DS_ERROR;
+    if( flusherr != 0 ) return SEGY_DS_FLUSH_ERROR;
 
     return SEGY_OK;
 }
@@ -759,7 +759,7 @@ int segy_close( segy_datasource* ds ) {
 
     err = ds->close(ds);
     free( ds );
-    if( err != 0 ) return SEGY_DS_ERROR;
+    if( err != 0 ) return SEGY_DS_CLOSE_ERROR;
     return SEGY_OK;
 }
 

--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -193,8 +193,9 @@ def create(filename, spec):
     if endian is None:
         endian = 'big'
 
-
-    fd = _segyio.segyfd(str(filename), 'w+', c_endianness(endian))
+    fd = _segyio.segyfd(
+        filename=str(filename), mode='w+', endianness=c_endianness(endian)
+    )
     fd.segymake(
         samples = len(samples),
         tracecount = tracecount,

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -149,7 +149,9 @@ def open(filename, mode="r", iline = 189,
         raise ValueError(', '.join((problem, solution)))
 
     from . import _segyio
-    fd = _segyio.segyfd(str(filename), mode, c_endianness(endian))
+    fd = _segyio.segyfd(
+        filename=str(filename), mode=mode, endianness=c_endianness(endian)
+    )
     fd.segyopen()
     metrics = fd.metrics()
 

--- a/python/segyio/segyio.cpp
+++ b/python/segyio/segyio.cpp
@@ -369,6 +369,12 @@ struct buffer_guard {
 };
 
 struct autods {
+    autods() : ds( nullptr ) {}
+
+    ~autods() {
+        this->close();
+    }
+
     operator segy_datasource*() const;
     operator bool() const;
     void swap( autods& other );
@@ -428,10 +434,8 @@ int init( segyfd* self, PyObject* args, PyObject* kwargs ) {
         return -1;
     }
 
-    struct unique : public autods {
-        explicit unique( segy_datasource* p ) { this->ds = p; }
-        ~unique() { this->close(); }
-    } ds( segy_open( filename, mode ) );
+    autods ds;
+    ds.ds = segy_open( filename, mode );
 
     if( !ds && !strstr( "rb" "wb" "ab" "r+b" "w+b" "a+b", mode ) ) {
         ValueError( "invalid mode string '%s', good strings are %s",

--- a/python/segyio/segyio.cpp
+++ b/python/segyio/segyio.cpp
@@ -154,44 +154,6 @@ PyObject* Error( int err ) {
     }
 }
 
-struct autods {
-    operator segy_datasource*() const;
-    operator bool() const;
-    void swap( autods& other );
-    int close();
-
-    segy_datasource* ds;
-};
-
-autods::operator segy_datasource*() const {
-    if( this->ds ) return this->ds;
-
-    IOError( "I/O operation on closed datasource" );
-    return NULL;
-}
-
-autods::operator bool() const { return this->ds; }
-
-void autods::swap( autods& other ) { std::swap( this->ds, other.ds ); }
-int autods::close() {
-    int err = SEGY_OK;
-    if( this->ds ) {
-        err = segy_close( this->ds );
-    }
-    this->ds = NULL;
-    return err;
-}
-
-struct segyfd {
-    PyObject_HEAD
-    autods ds;
-    long trace0;
-    int trace_bsize;
-    int tracecount;
-    int samplecount;
-    int format;
-    int elemsize;
-};
 
 struct buffer_guard {
     /* automate Py_buffer handling.
@@ -235,6 +197,45 @@ struct buffer_guard {
     char* buf() const { return this->buf< char >(); }
 
     Py_buffer buffer;
+};
+
+struct autods {
+    operator segy_datasource*() const;
+    operator bool() const;
+    void swap( autods& other );
+    int close();
+
+    segy_datasource* ds;
+};
+
+autods::operator segy_datasource*() const {
+    if( this->ds ) return this->ds;
+
+    IOError( "I/O operation on closed datasource" );
+    return NULL;
+}
+
+autods::operator bool() const { return this->ds; }
+
+void autods::swap( autods& other ) { std::swap( this->ds, other.ds ); }
+int autods::close() {
+    int err = SEGY_OK;
+    if( this->ds ) {
+        err = segy_close( this->ds );
+    }
+    this->ds = NULL;
+    return err;
+}
+
+struct segyfd {
+    PyObject_HEAD
+    autods ds;
+    long trace0;
+    int trace_bsize;
+    int tracecount;
+    int samplecount;
+    int format;
+    int elemsize;
 };
 
 namespace fd {

--- a/python/segyio/su/file.py
+++ b/python/segyio/su/file.py
@@ -82,7 +82,9 @@ def open(filename, mode = 'r', iline = 189,
         raise ValueError(', '.join((problem, solution)))
 
     from .. import _segyio
-    fd = _segyio.segyfd(str(filename), mode, c_endianness(endian))
+    fd = _segyio.segyfd(
+        filename=str(filename), mode=mode, endianness=c_endianness(endian)
+    )
     fd.suopen()
     metrics = fd.metrics()
 

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -13,6 +13,10 @@ import segyio
 import segyio._segyio as _segyio
 
 
+def segyfile(filename, mode, endianness):
+    return _segyio.segyfd(filename=filename, mode=mode, endianness=endianness)
+
+
 def test_binary_header_size():
     assert 400 == _segyio.binsize()
 
@@ -23,7 +27,7 @@ def test_textheader_size():
 
 def test_open_non_existing_file():
     with pytest.raises(IOError):
-        _ = _segyio.segyfd("non-existing", "r", 0)
+        _ = segyfile("non-existing", "r", 0)
 
 
 def test_close_non_existing_file():
@@ -32,12 +36,12 @@ def test_close_non_existing_file():
 
 
 def test_open_and_close_file():
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0)
     f.close()
 
 
 def test_open_flush_and_close_file():
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0)
     f.flush()
     f.close()
 
@@ -50,7 +54,7 @@ def test_read_text_header_mmap():
 
 
 def test_read_text_header(mmap=False):
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0)
     if mmap:
         f.mmap()
 
@@ -117,9 +121,9 @@ def get_instance_segyfile(tmpdir,
     f = os.path.join(path, file_name)
 
     if samples is not None:
-        return _segyio.segyfd(f, mode, 0).segymake(samples, tracecount)
+        return segyfile(f, mode, 0).segymake(samples, tracecount)
     else:
-        return _segyio.segyfd(f, mode, 0).segyopen()
+        return segyfile(f, mode, 0).segyopen()
 
 
 @tmpfiles(testdata / 'small.sgy')
@@ -152,7 +156,7 @@ def test_read_binary_header_fields_mmap():
 
 
 def test_read_binary_header_fields(mmap=False):
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0)
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0)
     if mmap:
         f.mmap()
 
@@ -175,7 +179,7 @@ def test_line_metrics_mmap():
 
 
 def test_line_metrics(mmap=False):
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -219,7 +223,7 @@ def test_metrics_mmap():
 
 
 def test_metrics(mmap=False):
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -251,7 +255,7 @@ def test_indices_mmap():
 
 
 def test_indices(mmap=False):
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -305,7 +309,7 @@ def test_fread_trace0_mmap():
 
 
 def test_fread_trace0(mmap=False):
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0).segyopen()
     if mmap:
         f.mmap()
 
@@ -428,7 +432,7 @@ def read_and_write_traceheader(f, mmap):
 
 
 def test_read_traceheaders():
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0).segyopen()
     read_traceheaders_forall(f, False)
     read_traceheaders_forall(f, True)
 
@@ -549,7 +553,7 @@ def read_line(f, metrics, iline_idx, xline_idx):
 
 
 def read_small(mmap=False):
-    f = _segyio.segyfd(str(testdata / 'small.sgy'), "r", 0).segyopen()
+    f = segyfile(str(testdata / 'small.sgy'), "r", 0).segyopen()
 
     if mmap:
         f.mmap()


### PR DESCRIPTION
Python end-user code is planned to be added in the next PR. 
segyio tests will be added in it as I/O methods are not supposed to be called directly from Python, but via other segyio functions. So it must be tested as a whole.

Lack of running examples might make this PR difficult to review though, so commits introducing datasource for users can be added if desirable.