### PR TITLE
Improve strings handling

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -85,8 +85,8 @@ jobs:
         run: |
             cmake -S . -B build           \
             -DCMAKE_BUILD_TYPE=Debug      \
-            -DCMAKE_C_FLAGS_DEBUG="-O0"   \
-            -DCMAKE_CXX_FLAGS_DEBUG="-O0" \
+            -DCMAKE_C_FLAGS_DEBUG="-g -O0"   \
+            -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
             -DBUILD_SHARED_LIBS=ON        \
             -DBUILD_PYTHON=OFF
             cmake --build build

--- a/lib/include/segyio/segy.h
+++ b/lib/include/segyio/segy.h
@@ -93,6 +93,11 @@ struct segy_datasource {
      */
     bool lsb;
 
+    /* EBCDIC or ASCII encoding. All text-reading functions should consult this
+     * property to determine string encoding.
+     */
+    int encoding;
+
     /* Setting for trace algorithms.
      *
      * If true, unnecessary data would be read into memory/written to the
@@ -190,6 +195,12 @@ int segy_set_format( segy_datasource*, int format );
  * MSB, regardless of the properties of the underlying file.
  */
 int segy_set_endianness( segy_datasource*, int opt );
+
+/* sets file to be EBCDIC/ASCII encoded. If no valid encoding is provided, one
+ * is automatically decided by consulting first text header character. If in
+ * doubt, EBCDIC encoding is assumed.
+ */
+int segy_set_encoding( segy_datasource*, int opt );
 
 /* Gets field datatype from field id. Depending on field value, binary or trace
  * mapping table would be used.
@@ -731,6 +742,11 @@ typedef enum {
     SEGY_MSB = 0,
     SEGY_LSB = 1,
 } SEGY_ENDIANNESS;
+
+typedef enum {
+    SEGY_EBCDIC = 0,
+    SEGY_ASCII = 1,
+} SEGY_ENCODING;
 
 typedef enum {
     SEGY_UNKNOWN_SORTING = 0,

--- a/lib/src/segy.def
+++ b/lib/src/segy.def
@@ -12,6 +12,7 @@ segy_sample_interval
 segy_format
 segy_set_format
 segy_set_endianness
+segy_set_encoding
 segy_get_field
 segy_set_field
 segy_get_field_int

--- a/lib/test/segy.cpp
+++ b/lib/test/segy.cpp
@@ -349,13 +349,17 @@ TEST_CASE_METHOD( smallbin,
 }
 
 TEST_CASE_METHOD( smallfix,
-                  "sample format/endianness can be overriden",
+                  "sample format/endianness/encoding can be overriden",
                   "[c.segy]" ) {
     Err err = segy_set_format( fp, SEGY_IEEE_FLOAT_4_BYTE );
     CHECK( err == Err::ok() );
 
     err = segy_set_endianness( fp, SEGY_LSB );
     CHECK( err == Err::ok() );
+
+    err = segy_set_encoding( fp, SEGY_ASCII );
+    CHECK( err == Err::ok() );
+    CHECK( fp->encoding == SEGY_ASCII );
 }
 
 TEST_CASE_METHOD( smallfix,

--- a/python/segyio/create.py
+++ b/python/segyio/create.py
@@ -120,6 +120,8 @@ def create(filename, spec):
         ext_headers : int
         endian : str { 'big', 'msb', 'little', 'lsb' }
             defaults to 'big'
+        encoding : {'ebcdic', 'ascii'}
+            defaults to 'ebcdic'.
 
 
     Examples
@@ -229,7 +231,11 @@ def _create(datasource_descriptor, spec):
     if endian is None:
         endian = 'big'
 
-    fd = datasource_descriptor.make_segyfile_descriptor(endian)
+    encoding = spec.encoding if hasattr(spec, 'encoding') else 'ebcdic'
+    if encoding is None:
+        encoding = 'ebcdic'
+
+    fd = datasource_descriptor.make_segyfile_descriptor(endian, encoding)
     fd.segymake(
         samples = len(samples),
         tracecount = tracecount,

--- a/python/segyio/open.py
+++ b/python/segyio/open.py
@@ -40,7 +40,8 @@ def open(filename, mode="r", iline = 189,
                              xline = 193,
                              strict = True,
                              ignore_geometry = False,
-                             endian = 'big'):
+                             endian = 'big',
+                             encoding = None):
     """Open a segy file.
 
     Opens a segy file and tries to figure out its sorting, inline numbers,
@@ -95,6 +96,12 @@ def open(filename, mode="r", iline = 189,
 
     endian : {'big', 'msb', 'little', 'lsb'}
         File endianness, big/msb (default) or little/lsb
+
+    encoding : {None, 'ebcdic', 'ascii'}
+        Encoding for text and strings for the whole file: None - auto detection
+        (default), ebcdic or ascii. ebcdic encoded strings would be translated
+        into latin-1 encoding as per SEG-Y specification. For ascii encoding
+        data would be returned as is.
 
     Returns
     -------
@@ -154,7 +161,7 @@ def open(filename, mode="r", iline = 189,
 
     return _open(
         FileDatasourceDescriptor(filename, mode),
-        iline, xline, strict, ignore_geometry, endian
+        iline, xline, strict, ignore_geometry, endian, encoding
     )
 
 
@@ -164,6 +171,7 @@ def open_with(stream,
               strict=True,
               ignore_geometry=False,
               endian='big',
+              encoding=None,
               minimize_requests_number=True
               ):
     """
@@ -194,7 +202,7 @@ def open_with(stream,
             stream,
             minimize_requests_number
         ),
-        iline, xline, strict, ignore_geometry, endian
+        iline, xline, strict, ignore_geometry, endian, encoding
     )
 
 
@@ -203,7 +211,9 @@ def open_from_memory(memory_buffer,
                    xline=193,
                    strict=True,
                    ignore_geometry=False,
-                   endian='big'):
+                   endian='big',
+                   encoding=None,
+                   ):
     """
     Opens a segy file from memory.
 
@@ -224,7 +234,7 @@ def open_from_memory(memory_buffer,
         MemoryBufferDatasourceDescriptor(
             memory_buffer
         ),
-        iline, xline, strict, ignore_geometry, endian
+        iline, xline, strict, ignore_geometry, endian, encoding
     )
 
 
@@ -233,9 +243,11 @@ def _open(datasource_descriptor,
           xline=193,
           strict=True,
           ignore_geometry=False,
-          endian='big'):
+          endian='big',
+          encoding=None,
+          ):
 
-    fd = datasource_descriptor.make_segyfile_descriptor(endian)
+    fd = datasource_descriptor.make_segyfile_descriptor(endian, encoding)
     fd.segyopen()
     metrics = fd.metrics()
 

--- a/python/segyio/segy.py
+++ b/python/segyio/segy.py
@@ -54,6 +54,7 @@ class SegyFile(object):
         self._fmt = metrics['format']
         self._tracecount = metrics['tracecount']
         self._ext_headers = metrics['ext_headers']
+        self._encoding = metrics['encoding']
 
         try:
             self._dtype = np.dtype({
@@ -843,6 +844,18 @@ class SegyFile(object):
         return fmt()
 
     @property
+    def encoding(self):
+        d = {
+            0: "ebcdic",
+            1: "ascii",
+        }
+
+        if not self._encoding in d:
+            return "Unknown encoding"
+
+        return d[self._encoding]
+
+    @property
     def readonly(self):
         """File is read-only
 
@@ -1011,3 +1024,4 @@ class spec(object):
         self.format = None
         self.sorting = None
         self.endian = 'big'
+        self.encoding = 'ebcdic'

--- a/python/segyio/segyio.cpp
+++ b/python/segyio/segyio.cpp
@@ -391,7 +391,7 @@ struct autods {
 autods::operator segy_datasource*() const {
     if( this->ds ) return this->ds;
 
-    IOError( "I/O operation on closed datasource" );
+    ValueError( "I/O operation on closed datasource" );
     return NULL;
 }
 

--- a/python/segyio/tools.py
+++ b/python/segyio/tools.py
@@ -347,6 +347,7 @@ def metadata(f):
 
     spec.ext_headers = f.ext_headers
     spec.endian = f.endian
+    spec.encoding = f.encoding
 
     return spec
 

--- a/python/segyio/trace.py
+++ b/python/segyio/trace.py
@@ -885,11 +885,14 @@ class Text(Sequence):
         Print a textual header line-by-line:
 
         >>> # using zip, from the zip documentation
-        >>> text = str(f.text[0])
+        >>> text = f.text[0].decode('ascii', errors='replace')
         >>> lines = map(''.join, zip( *[iter(text)] * 80))
         >>> for line in lines:
         ...     print(line)
         ...
+
+        Or use segyio.tools.wrap:
+        >>> text = segyio.tools.wrap(f.text[0].decode('latin-1'))
         """
         try:
             i = self.wrapindex(i)
@@ -959,9 +962,3 @@ class Text(Sequence):
                 if isinstance(text, Text):
                     text = text[0]
                 self.segyfd.puttext(i, text)
-
-
-    def __str__(self):
-        msg = 'str(text) is deprecated, use explicit format instead'
-        warnings.warn(msg, DeprecationWarning)
-        return '\n'.join(map(''.join, zip(*[iter(str(self[0]))] * 80)))

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -210,6 +210,7 @@ def test_file_info(openfn, kwargs):
         assert 1 == f.offsets
         assert 1 == int(f.format)
         assert np.single == f.dtype
+        assert 'ebcdic' == f.encoding
 
         xlines = list(range(20, 25))
         ilines = list(range(1, 6))
@@ -676,6 +677,17 @@ def test_read_text_sequence():
         with pytest.deprecated_call():
             str(f.text)
 
+        # file is ebcdic encoded, but values are returned as ascii
+        assert f.encoding == "ebcdic"
+        assert len(f.text[0]) == 3200
+        assert f.text[0][0] == 67  # "C" character in ASCII
+
+    with segyio.open(testdata / 'delay-scalar.sgy', ignore_geometry=True) as f:
+        # file is ascii encoded and values are returned as ascii
+        assert f.encoding == "ascii"
+        assert len(f.text[0]) == 3200
+        assert f.text[0][0] == 67
+
 
 @tmpfiles(testdata / 'multi-text.sgy')
 def test_put_text_sequence(tmpdir):
@@ -700,6 +712,46 @@ def test_put_text_sequence(tmpdir):
     with segyio.open(fname, ignore_geometry = True) as f:
         for text in f.text:
             assert text == ref
+
+
+def test_update_text_encoding(small):
+    lines = {1: 'first line', 10: 'last line'}
+    ref = bytes(segyio.tools.create_text_header(lines), 'ascii')
+
+    encodings = ['ascii', 'ebcdic']
+
+    for write_encoding in encodings:
+        with segyio.open(small, mode='r+', encoding=write_encoding) as f:
+            f.text[0] = ref
+
+        with segyio.open(small) as f:
+            assert f.text[0] == ref
+
+        for read_encoding in encodings:
+            with segyio.open(small, encoding=read_encoding) as f:
+                if read_encoding == write_encoding:
+                    assert f.text[0] == ref
+                else:
+                    assert f.text[0] != ref
+
+
+def test_create_ascii_text(tmpdir):
+    fresh = str(tmpdir / 'fresh.sgy')
+
+    lines = {1: 'first line', 10: 'last line'}
+    ref = bytes(segyio.tools.create_text_header(lines), 'ascii')
+
+    spec = segyio.tools.metadata(testdata / 'small-ps.sgy')
+    spec.encoding = "ascii"
+
+    with segyio.create(fresh, spec) as f:
+        for i in range(spec.tracecount):
+            f.trace[i] = np.zeros(len(spec.samples), dtype=np.single)
+        f.text[0] = ref
+
+    with segyio.open(fresh, ignore_geometry=True) as f:
+        assert f.text[0] == ref
+
 
 @pytest.mark.parametrize(('openfn', 'kwargs'), smallfiles)
 def test_header_getitem_intlikes(openfn, kwargs):

--- a/python/test/segy.py
+++ b/python/test/segy.py
@@ -674,19 +674,27 @@ def test_read_text_sequence():
             assert text
 
         assert iter(f.text)
-        with pytest.deprecated_call():
-            str(f.text)
 
         # file is ebcdic encoded, but values are returned as ascii
         assert f.encoding == "ebcdic"
         assert len(f.text[0]) == 3200
         assert f.text[0][0] == 67  # "C" character in ASCII
 
+        decoded = f.text[0].decode('latin-1')
+        lines = list(map(''.join, zip(*[iter(decoded)] * 80)))
+        for line in lines:
+            assert line.startswith('C')
+
     with segyio.open(testdata / 'delay-scalar.sgy', ignore_geometry=True) as f:
         # file is ascii encoded and values are returned as ascii
         assert f.encoding == "ascii"
         assert len(f.text[0]) == 3200
         assert f.text[0][0] == 67
+
+        decoded = f.text[0].decode('ascii', errors='replace')
+        lines = list(map(''.join, zip(*[iter(decoded)] * 80)))
+        for line in lines:
+            assert line.startswith('C')
 
 
 @tmpfiles(testdata / 'multi-text.sgy')

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -247,6 +247,7 @@ def test_metrics(mmap=False):
     assert metrics['offset_count'] == 1
     assert metrics['iline_count'] == 5
     assert metrics['xline_count'] == 5
+    assert metrics['encoding'] == 0
 
     f.close()
 

--- a/python/test/segyio_c.py
+++ b/python/test/segyio_c.py
@@ -46,7 +46,7 @@ def test_open_flush_and_close_file():
     f.flush()
     f.close()
 
-    with pytest.raises(IOError):
+    with pytest.raises(ValueError):
         f.flush()
 
 

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -185,6 +185,7 @@ def test_metadata():
     assert np.array_equal(spec.samples, smallspec.samples)
     assert spec.sorting == smallspec.sorting
     assert spec.format == int(smallspec.format)
+    assert spec.encoding == smallspec.encoding
 
 
 @tmpfiles(testdata / 'small.sgy')

--- a/python/test/tools.py
+++ b/python/test/tools.py
@@ -83,6 +83,11 @@ def test_wrap_only_stringifies_content():
         s = segyio.tools.wrap(f.text[0].decode(errors = 'ignore'))
         assert s.startswith('C 1')
 
+    with segyio.open(testdata / 'delay-scalar.sgy', ignore_geometry=True) as f:
+        assert f.encoding == 'ascii'
+        s = segyio.tools.wrap(f.text[0].decode("ascii"))
+        assert s.startswith('C 1')
+
 
 def test_values_text_header_creation():
     lines = {i + 1: chr(64 + i) * 76 for i in range(40)}


### PR DESCRIPTION
1. ASCII encoding support was added as it was requested several times already.
2. EBCDIC tables are updated according to SEG-Y specification.
3. Not yet done string-related breaking changes are applied, as well as I understood them.

Those might cause some slight breaking changes for the users, but most likely only if files were weird-ish or there was some hardcoded way to deal with ASCII files.

Note: even though strings and encodings are now supported, Trace Header bytes 233-240 are not updated to read string from it. I did that originally, but then after discussion with PO we agreed to leave Unassigned 1 and Unassigned 2 as is. Reason for this is that in revision 1.0 space is defined as
`233-240 Unassigned — For optional information`
and someone might have used that as ints before.