### PR TITLE
Drop macos intel support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,10 +56,6 @@ jobs:
             build_type: "Debug"
             compiler_flags: "-Wextra -Wall -pedantic"
             build_python: "OFF"
-          - os: macos-13
-            privledges: "sudo"
-            build_type: "Release"
-            build_python: "OFF"
           - os: macos-latest
             privledges: "sudo"
             build_type: "Release"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,8 +33,6 @@ jobs:
             arch: i686
           # macos-latest runs on arm64 architecture and cibuildwheel cross
           # compiling for x86_64 fails
-          - os: macos-13
-            arch: x86_64
           - os: macos-latest
             arch: arm64
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # segyio #
 
-[![Travis](https://img.shields.io/travis/equinor/segyio/master.svg?label=travis)](https://travis-ci.org/equinor/segyio)
-[![Appveyor](https://ci.appveyor.com/api/projects/status/2i5cr8ui2t9qbxk9?svg=true)](https://ci.appveyor.com/project/statoil-travis/segyio)
-[![PyPI Updates](https://pyup.io/repos/github/equinor/segyio/shield.svg)](https://pyup.io/repos/github/equinor/segyio/)
-[![Python 3](https://pyup.io/repos/github/equinor/segyio/python-3-shield.svg)](https://pyup.io/repos/github/equinor/segyio/)
+[![PyPI - Version](https://img.shields.io/pypi/v/segyio)](https://pypi.org/project/segyio/)
+[![Read the Docs](https://img.shields.io/readthedocs/segyio)](https://segyio.readthedocs.io/)
 
 > [!NOTE]
 > 🚧 *segyio 2.0* is under construction in the `main` branch. 🚧


### PR DESCRIPTION
Macos Intel will end support soon. Github actions will drop the image.
As we prepare for 2.0 release, we can drop it already now and leave it be in the version-1.x branch only.