### PR TITLE
Use trusted publisher for PyPI publication

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -70,6 +70,13 @@ jobs:
     name: Publish wheels to PyPI
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+    environment:
+      name: pypi
+
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -80,9 +87,6 @@ jobs:
           path: ./wheelhouse/
 
       - name: Publish wheels to PyPI
-
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: ./wheelhouse/


### PR DESCRIPTION
The branch contains several commits (currently the last three) to have a simpler workflow for testing publication to TestPyPI. This breaks some of the windows tests. 

Successful publication to TestPyPI happened in [this GitHub Action workflow](https://github.com/ajaust/segyio/actions/runs/18943837389). The pushed package is [in this TestPyPI repository](https://test.pypi.org/project/test-segyio-2025/). Relevant documentation about [publishing using trusted publishers](https://docs.pypi.org/trusted-publishers/using-a-publisher/).