### PR TITLE
Remove forgotten step in benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -41,11 +41,6 @@ jobs:
           ref: ${{ env.BENCHMARK_REF }}
           compare: ""
 
-      # Head of repository is incompatible with cibuildwheel < 3.0.0 due to
-      # using the "test-sources" feature in pyproject.toml
-      - name: Update cibuildwheel for new commit
-        run: python3 -m pip install --upgrade cibuildwheel
-
       - name: Benchmark current commit and compare
         uses: "./.github/actions/benchmark"
         with:


### PR DESCRIPTION
Follow-up to bb05dae531860608ec9f5d3bb5a2eafb490b9b2f where we use same cbuildwheel for both old and new paths.